### PR TITLE
Create build-test.yml

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build and Test
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+    - name: install
+      run: npm ci
+    - name: build
+      run: npm run compile
+    - name: test
+      run: npm test


### PR DESCRIPTION
Github action to install, build and test project on push and pull requests on main branch.

Using npm ci instead of npm install
npm ci will:
- delete your node_modules folder to ensure a clean state.
- look in your package-lock.json to install all the dependencies with the exact version.
- Unlike npm install, npm ci will never modify your package-lock.json. 