### PR TITLE
add build cache

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,12 +13,19 @@ jobs:
 
     steps: 
     - uses: actions/checkout@v2
+
     - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with: 
         node-version: '14.x'
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
     - run: npm ci
-    - run: npm run compile
     - run: npm test
 
     - name: Upload coverage to Codecov  


### PR DESCRIPTION
closes #32 

sample build here: https://github.com/noelbundick/config-analyzer/runs/1963693438?check_suite_focus=true

removes double compile - `npm run compile` is already configured in the package.json pretest section

