### PR TITLE
Resource graph rule

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,57 +1,61 @@
-import { ResourcesResponse } from "@azure/arm-resourcegraph/esm/models";
-import { DefaultAzureCredential } from "@azure/identity";
-import { AzureClient } from "./azure"
+import {ResourcesResponse} from '@azure/arm-resourcegraph/esm/models';
+import {DefaultAzureCredential} from '@azure/identity';
+import {AzureClient} from './azure';
 
 export interface Rule {
   name: string;
   description: string;
-  resourceGraph?: ResourceGraphQuery
+  resourceGraph?: ResourceGraphQuery;
 }
 
 export type ResourceGraphQuery = {
-    type: 'resourceGraph'
-    query: string
-}
+  type: 'resourceGraph';
+  query: string;
+};
 
 export interface RuleExecutor {
   execute(): Promise<ScanResult>;
 }
 
 export interface ScanResult {
-    ruleName: string;
-    total: number;
-    ids: string[];
+  ruleName: string;
+  total: number;
+  ids: string[];
 }
 
 interface QueryResponseColumn {
-    name: string;
-    type: string | object; 
+  name: string;
+  type: string | object;
 }
 
 export class ResourceGraphRule implements RuleExecutor {
-    name: string;
-    query: string;
-    subscriptionId: string;
+  name: string;
+  query: string;
+  subscriptionId: string;
 
-    constructor(name: string, queryObj: ResourceGraphQuery, subscriptionId: string){
-        this.name = name;
-        this.query = queryObj.query;
-        this.subscriptionId = subscriptionId;
-    }
+  constructor(name: string, query: ResourceGraphQuery, subscriptionId: string) {
+    this.name = name;
+    this.query = query.query;
+    this.subscriptionId = subscriptionId;
+  }
 
-    execute(){
-        const credential = new DefaultAzureCredential();
-        const client = new AzureClient(credential);
-        const resources = client.queryResources(this.query, [this.subscriptionId]) 
-        return resources.then(r => this.toScanResult(r))
-    }
+  async execute() {
+    const credential = new DefaultAzureCredential();
+    const client = new AzureClient(credential);
+    const resources = client.queryResources(this.query, [this.subscriptionId]);
+    return await resources.then(r => this.toScanResult(r));
+  }
 
-    private toScanResult(response: ResourcesResponse){
-        const cols = response.data.columns as QueryResponseColumn[]
-        const rows = response.data.rows as []
-        const idIndex = cols.findIndex(c => c.name === 'id') 
-        const resourceIds = rows.map(r => r[idIndex]) 
-        const scanResult = {ruleName: this.name, total: response.totalRecords, ids: resourceIds}
-        return scanResult 
-    }
+  private toScanResult(response: ResourcesResponse) {
+    const cols = response.data.columns as QueryResponseColumn[];
+    const rows = response.data.rows as [];
+    const idIndex = cols.findIndex(c => c.name === 'id');
+    const resourceIds = rows.map(r => r[idIndex]);
+    const scanResult = {
+      ruleName: this.name,
+      total: response.totalRecords,
+      ids: resourceIds,
+    };
+    return scanResult;
+  }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -5,11 +5,12 @@ import { AzureClient } from "./azure"
 export interface Rule {
   name: string;
   description: string;
-  resourceGraph?: ResourceGraphQuery;
+  resourceGraph?: ResourceGraphQuery
 }
 
-export interface ResourceGraphQuery {
-  query: string;
+export type ResourceGraphQuery = {
+    type: 'resourceGraph'
+    query: string
 }
 
 export interface RuleExecutor {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,20 +1,21 @@
-import {ResourcesResponse} from '@azure/arm-resourcegraph/esm/models';
+import {ResourceGraphModels} from '@azure/arm-resourcegraph';
 import {DefaultAzureCredential} from '@azure/identity';
 import {AzureClient} from './azure';
 
-export type Rule = ResourceGraphRule;
+export type RuleSchema = ResourceGraphRuleSchema;
+export type RuleExecutor = ResourceGraphRule;
 
-export interface IRule {
+interface BaseRuleSchema {
   name: string;
   description: string;
   type: string;
 }
 
-interface IExecute {
+interface Execute {
   execute(): Promise<ScanResult>;
 }
 
-export interface IResourceGraphRule extends IRule {
+interface ResourceGraphRuleSchema extends BaseRuleSchema {
   type: 'resourceGraph';
   query: string;
 }
@@ -31,14 +32,14 @@ interface ResourceGraphQueryResponseColumn {
   type: string | object;
 }
 
-export class ResourceGraphRule implements IResourceGraphRule, IExecute {
+export class ResourceGraphRule implements Execute {
   type: 'resourceGraph';
   name: string;
   description: string;
   query: string;
   subscriptionId: string;
 
-  constructor(rule: IResourceGraphRule, subscriptionId: string) {
+  constructor(rule: ResourceGraphRuleSchema, subscriptionId: string) {
     this.type = rule.type;
     this.name = rule.name;
     this.description = rule.description;
@@ -55,7 +56,7 @@ export class ResourceGraphRule implements IResourceGraphRule, IExecute {
     return this.toScanResult(resources);
   }
 
-  private toScanResult(response: ResourcesResponse) {
+  private toScanResult(response: ResourceGraphModels.ResourcesResponse) {
     const cols = response.data.columns as ResourceGraphQueryResponseColumn[];
     const rows = response.data.rows as string[];
     const idIndex = cols.findIndex(c => c.name === 'id');

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,3 +1,7 @@
+import { ResourcesResponse } from "@azure/arm-resourcegraph/esm/models";
+import { DefaultAzureCredential } from "@azure/identity";
+import { AzureClient } from "./azure"
+
 export interface Rule {
   name: string;
   description: string;
@@ -16,4 +20,37 @@ export interface ScanResult {
     ruleName: string;
     total: number;
     ids: string[];
+}
+
+interface QueryResponseColumn {
+    name: string;
+    type: string | object; 
+}
+
+export class ResourceGraphRule implements RuleExecutor {
+    name: string;
+    query: string;
+    subscriptionId: string;
+
+    constructor(name: string, queryObj: ResourceGraphQuery, subscriptionId: string){
+        this.name = name;
+        this.query = queryObj.query;
+        this.subscriptionId = subscriptionId;
+    }
+
+    execute(){
+        const credential = new DefaultAzureCredential();
+        const client = new AzureClient(credential);
+        const resources = client.queryResources(this.query, [this.subscriptionId]) 
+        return resources.then(r => this.toScanResult(r))
+    }
+
+    private toScanResult(response: ResourcesResponse){
+        const cols = response.data.columns as QueryResponseColumn[]
+        const rows = response.data.rows as []
+        const idIndex = cols.findIndex(c => c.name === 'id') 
+        const resourceIds = rows.map(r => r[idIndex]) 
+        const scanResult = {ruleName: this.name, total: response.totalRecords, ids: resourceIds}
+        return scanResult 
+    }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2,9 +2,9 @@ import {ResourcesResponse} from '@azure/arm-resourcegraph/esm/models';
 import {DefaultAzureCredential} from '@azure/identity';
 import {AzureClient} from './azure';
 
-export type Rule = IResourceGraphRule;
+export type Rule = ResourceGraphRule;
 
-export interface IRuleData {
+export interface IRule {
   name: string;
   description: string;
   type: string;
@@ -14,7 +14,7 @@ interface IExecute {
   execute(): Promise<ScanResult>;
 }
 
-interface IResourceGraphRule extends IRuleData, IExecute {
+export interface IResourceGraphRule extends IRule {
   type: 'resourceGraph';
   query: string;
 }
@@ -31,7 +31,7 @@ interface ResourceGraphQueryResponseColumn {
   type: string | object;
 }
 
-export class ResourceGraphRule implements IResourceGraphRule {
+export class ResourceGraphRule implements IResourceGraphRule, IExecute {
   type: 'resourceGraph';
   name: string;
   description: string;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2,12 +2,15 @@ import {ResourcesResponse} from '@azure/arm-resourcegraph/esm/models';
 import {DefaultAzureCredential} from '@azure/identity';
 import {AzureClient} from './azure';
 
-export type Rule = ResourceGraphRule;
+export type Rule = IResourceGraphRule;
 
 interface IRule {
   name: string;
   description: string;
   type: string;
+}
+
+interface IExecute {
   execute(): Promise<ScanResult>;
 }
 
@@ -28,7 +31,7 @@ interface ResourceGraphQueryResponseColumn {
   type: string | object;
 }
 
-export class ResourceGraphRule implements IResourceGraphRule {
+export class ResourceGraphRule implements IResourceGraphRule, IExecute {
   type: 'resourceGraph';
   name: string;
   description: string;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -4,7 +4,7 @@ import {AzureClient} from './azure';
 
 export type Rule = IResourceGraphRule;
 
-interface IRule {
+export interface IRuleData {
   name: string;
   description: string;
   type: string;
@@ -14,7 +14,7 @@ interface IExecute {
   execute(): Promise<ScanResult>;
 }
 
-interface IResourceGraphRule extends IRule {
+interface IResourceGraphRule extends IRuleData, IExecute {
   type: 'resourceGraph';
   query: string;
 }
@@ -31,7 +31,7 @@ interface ResourceGraphQueryResponseColumn {
   type: string | object;
 }
 
-export class ResourceGraphRule implements IResourceGraphRule, IExecute {
+export class ResourceGraphRule implements IResourceGraphRule {
   type: 'resourceGraph';
   name: string;
   description: string;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -7,3 +7,12 @@ export interface Rule {
 export interface ResourceGraphQuery {
   query: string;
 }
+
+export interface RuleExecutor {
+  execute(): Promise<ScanResult>;
+}
+
+export interface ScanResult {
+  id: string;
+  ruleName: string;
+}

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -13,6 +13,7 @@ export interface RuleExecutor {
 }
 
 export interface ScanResult {
-  id: string;
-  ruleName: string;
+    ruleName: string;
+    total: number;
+    ids: string[];
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -38,16 +38,11 @@ export class ResourceGraphRule implements IResourceGraphRule, IExecute {
   query: string;
   subscriptionId: string;
 
-  constructor(
-    name: string,
-    description: string,
-    query: string,
-    subscriptionId: string
-  ) {
-    this.type = 'resourceGraph';
-    this.name = name;
-    this.description = description;
-    this.query = query;
+  constructor(rule: IResourceGraphRule, subscriptionId: string) {
+    this.type = rule.type;
+    this.name = rule.name;
+    this.description = rule.description;
+    this.query = rule.query;
     this.subscriptionId = subscriptionId;
   }
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2,57 +2,69 @@ import {ResourcesResponse} from '@azure/arm-resourcegraph/esm/models';
 import {DefaultAzureCredential} from '@azure/identity';
 import {AzureClient} from './azure';
 
-export interface Rule {
+export type Rule = ResourceGraphRule;
+
+interface IRule {
   name: string;
   description: string;
-  resourceGraph?: ResourceGraphQuery;
+  type: string;
+  execute(): Promise<ScanResult>;
 }
 
-export type ResourceGraphQuery = {
+interface IResourceGraphRule extends IRule {
   type: 'resourceGraph';
   query: string;
-};
-
-export interface RuleExecutor {
-  execute(): Promise<ScanResult>;
 }
 
 export interface ScanResult {
   ruleName: string;
+  description: string;
   total: number;
   ids: string[];
 }
 
-interface QueryResponseColumn {
+interface ResourceGraphQueryResponseColumn {
   name: string;
   type: string | object;
 }
 
-export class ResourceGraphRule implements RuleExecutor {
+export class ResourceGraphRule implements IResourceGraphRule {
+  type: 'resourceGraph';
   name: string;
+  description: string;
   query: string;
   subscriptionId: string;
 
-  constructor(name: string, query: ResourceGraphQuery, subscriptionId: string) {
+  constructor(
+    name: string,
+    description: string,
+    query: string,
+    subscriptionId: string
+  ) {
+    this.type = 'resourceGraph';
     this.name = name;
-    this.query = query.query;
+    this.description = description;
+    this.query = query;
     this.subscriptionId = subscriptionId;
   }
 
   async execute() {
     const credential = new DefaultAzureCredential();
     const client = new AzureClient(credential);
-    const resources = client.queryResources(this.query, [this.subscriptionId]);
-    return await resources.then(r => this.toScanResult(r));
+    const resources = await client.queryResources(this.query, [
+      this.subscriptionId,
+    ]);
+    return this.toScanResult(resources);
   }
 
   private toScanResult(response: ResourcesResponse) {
-    const cols = response.data.columns as QueryResponseColumn[];
-    const rows = response.data.rows as [];
+    const cols = response.data.columns as ResourceGraphQueryResponseColumn[];
+    const rows = response.data.rows as string[];
     const idIndex = cols.findIndex(c => c.name === 'id');
     const resourceIds = rows.map(r => r[idIndex]);
     const scanResult = {
       ruleName: this.name,
+      description: this.description,
       total: response.totalRecords,
       ids: resourceIds,
     };

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -1,12 +1,13 @@
 import {assert} from 'chai';
-import {ResourceGraphRule, Rule} from '../src/rules';
+import {IResourceGraphRule, ResourceGraphRule} from '../src/rules';
 import * as env from 'env-var';
 import {environment} from './constants';
 
 describe('Resource Graph Rule', function () {
-  this.slow(4000);
-  this.timeout(7000);
+  this.slow(5000);
+  this.timeout(8000);
   let subscriptionId: string;
+  subscriptionId = env.get(environment.subscriptionId).required().asString();
 
   before(function () {
     const runIntegrationTests = env
@@ -28,7 +29,12 @@ describe('Resource Graph Rule', function () {
       "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'";
     const name = 'Dummy Rule';
     const description = 'Intentional bad query';
-    const rule: Rule = {name, query, description, type: 'resourceGraph'};
+    const rule: IResourceGraphRule = {
+      name,
+      query,
+      description,
+      type: 'resourceGraph',
+    };
     const rgr = new ResourceGraphRule(rule, subscriptionId);
     const result = await rgr.execute().catch(err => {
       return {

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -1,11 +1,11 @@
 import {assert} from 'chai';
-import {ResourceGraphRule} from '../src/rules';
+import {ResourceGraphRule, Rule} from '../src/rules';
 import * as env from 'env-var';
 import {environment} from './constants';
 
 describe('Resource Graph Rule', function () {
-  this.slow(3000);
-  this.timeout(5000);
+  this.slow(4000);
+  this.timeout(7000);
   let subscriptionId: string;
 
   before(function () {
@@ -20,14 +20,9 @@ describe('Resource Graph Rule', function () {
       "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'";
     const name = 'Dummy Rule';
     const description = 'Intentional bad query';
-    const rule = new ResourceGraphRule(
-      name,
-      description,
-      query,
-      subscriptionId
-    );
-
-    const result = await rule.execute();
+    const rule: Rule = {name, query, description, type: 'resourceGraph'};
+    const rgr = new ResourceGraphRule(name, description, query, subscriptionId);
+    const result = await rgr.execute();
     assert.equal(rule.name, result.ruleName);
     assert.equal(rule.description, result.description);
     assert.containsAllKeys(result, ['ruleName', 'description', 'total', 'ids']);

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -9,8 +9,16 @@ describe('Resource Graph Rule', function () {
   let subscriptionId: string;
 
   before(function () {
-    subscriptionId = env.get(environment.subscriptionId).asString() || '';
-    if (!subscriptionId) {
+    const runIntegrationTests = env
+      .get(environment.runIntegrationTests)
+      .default('false')
+      .asBoolStrict();
+    subscriptionId = env
+      .get(environment.subscriptionId)
+      .required(runIntegrationTests)
+      .asString();
+
+    if (!runIntegrationTests) {
       this.skip();
     }
   });

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -21,7 +21,7 @@ describe('Resource Graph Rule', function () {
     const name = 'Dummy Rule';
     const description = 'Intentional bad query';
     const rule: Rule = {name, query, description, type: 'resourceGraph'};
-    const rgr = new ResourceGraphRule(name, description, query, subscriptionId);
+    const rgr = new ResourceGraphRule(rule, subscriptionId);
     const result = await rgr.execute();
     assert.equal(rule.name, result.ruleName);
     assert.equal(rule.description, result.description);

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -1,0 +1,40 @@
+import {assert} from 'chai';
+import {ResourceGraphQuery, ResourceGraphRule} from '../src/rules';
+import * as env from 'env-var';
+import {environment} from './constants';
+
+describe('Resource Graph Rule', () => {
+  let subscriptionId = '';
+
+  before(function () {
+    subscriptionId = env.get(environment.subscriptionId).required().asString();
+
+    if (!subscriptionId) {
+      this.skip();
+    }
+  });
+
+  it('can execute a resource graph rule and return a scan result', async () => {
+    const query =
+      "Resources | where type =~ 'Microsoft.Compute/virtualMachines'";
+    const rule = {
+      name: 'Dummy Rule',
+      description: '',
+      resourceGraph: {
+        type: 'resourceGraph',
+        query,
+      } as ResourceGraphQuery,
+    };
+
+    const rgRule = new ResourceGraphRule(
+      rule.name,
+      rule.resourceGraph,
+      subscriptionId
+    );
+
+    const result = await rgRule.execute();
+    assert.equal(rule.name, result.ruleName);
+    assert.containsAllKeys(result, ['ruleName', 'total', 'ids']);
+    assert.equal(result.total, result.ids.length);
+  });
+});

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -3,11 +3,12 @@ import {ResourceGraphQuery, ResourceGraphRule} from '../src/rules';
 import * as env from 'env-var';
 import {environment} from './constants';
 
-describe('Resource Graph Rule', () => {
-  let subscriptionId = '';
+describe('Resource Graph Rule', function () {
+  this.slow(3000);
+  let subscriptionId: string | undefined;
 
   before(function () {
-    subscriptionId = env.get(environment.subscriptionId).required().asString();
+    subscriptionId = env.get(environment.subscriptionId).asString();
 
     if (!subscriptionId) {
       this.skip();
@@ -29,7 +30,7 @@ describe('Resource Graph Rule', () => {
     const rgRule = new ResourceGraphRule(
       rule.name,
       rule.resourceGraph,
-      subscriptionId
+      subscriptionId || ''
     );
 
     const result = await rgRule.execute();

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -22,10 +22,18 @@ describe('Resource Graph Rule', function () {
     const description = 'Intentional bad query';
     const rule: Rule = {name, query, description, type: 'resourceGraph'};
     const rgr = new ResourceGraphRule(rule, subscriptionId);
-    const result = await rgr.execute();
+    const result = await rgr.execute().catch(err => {
+      return {
+        err,
+        ruleName: rgr.name,
+        description,
+        total: 0,
+        ids: [],
+      };
+    });
     assert.equal(rule.name, result.ruleName);
     assert.equal(rule.description, result.description);
     assert.containsAllKeys(result, ['ruleName', 'description', 'total', 'ids']);
-    assert.equal(result.total, result.ids.length);
+    assert.equal(result.total, 0);
   });
 });

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {IResourceGraphRule, ResourceGraphRule} from '../src/rules';
+import {RuleSchema, ResourceGraphRule} from '../src/rules';
 import * as env from 'env-var';
 import {environment} from './constants';
 
@@ -28,25 +28,27 @@ describe('Resource Graph Rule', function () {
       "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'";
     const name = 'Dummy Rule';
     const description = 'Intentional bad query';
-    const rule: IResourceGraphRule = {
+    const rule: RuleSchema = {
       name,
       query,
       description,
       type: 'resourceGraph',
     };
     const rgr = new ResourceGraphRule(rule, subscriptionId);
-    const result = await rgr.execute().catch(err => {
-      return {
-        err,
-        ruleName: rgr.name,
-        description,
-        total: 0,
-        ids: [],
-      };
-    });
-    assert.equal(rule.name, result.ruleName);
-    assert.equal(rule.description, result.description);
-    assert.containsAllKeys(result, ['ruleName', 'description', 'total', 'ids']);
-    assert.equal(result.total, 0);
+
+    try {
+      const result = await rgr.execute();
+      assert.equal(rule.name, result.ruleName);
+      assert.equal(rule.description, result.description);
+      assert.containsAllKeys(result, [
+        'ruleName',
+        'description',
+        'total',
+        'ids',
+      ]);
+      assert.equal(result.total, 0);
+    } catch (err) {
+      throw new Error('Could not execute the rule');
+    }
   });
 });

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -7,7 +7,6 @@ describe('Resource Graph Rule', function () {
   this.slow(5000);
   this.timeout(8000);
   let subscriptionId: string;
-  subscriptionId = env.get(environment.subscriptionId).required().asString();
 
   before(function () {
     const runIntegrationTests = env

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -1,15 +1,15 @@
 import {assert} from 'chai';
-import {ResourceGraphQuery, ResourceGraphRule} from '../src/rules';
+import {ResourceGraphRule} from '../src/rules';
 import * as env from 'env-var';
 import {environment} from './constants';
 
 describe('Resource Graph Rule', function () {
   this.slow(3000);
-  let subscriptionId: string | undefined;
+  this.timeout(5000);
+  let subscriptionId: string;
 
   before(function () {
-    subscriptionId = env.get(environment.subscriptionId).asString();
-
+    subscriptionId = env.get(environment.subscriptionId).asString() || '';
     if (!subscriptionId) {
       this.skip();
     }
@@ -17,25 +17,20 @@ describe('Resource Graph Rule', function () {
 
   it('can execute a resource graph rule and return a scan result', async () => {
     const query =
-      "Resources | where type =~ 'Microsoft.Compute/virtualMachines'";
-    const rule = {
-      name: 'Dummy Rule',
-      description: '',
-      resourceGraph: {
-        type: 'resourceGraph',
-        query,
-      } as ResourceGraphQuery,
-    };
-
-    const rgRule = new ResourceGraphRule(
-      rule.name,
-      rule.resourceGraph,
-      subscriptionId || ''
+      "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'";
+    const name = 'Dummy Rule';
+    const description = 'Intentional bad query';
+    const rule = new ResourceGraphRule(
+      name,
+      description,
+      query,
+      subscriptionId
     );
 
-    const result = await rgRule.execute();
+    const result = await rule.execute();
     assert.equal(rule.name, result.ruleName);
-    assert.containsAllKeys(result, ['ruleName', 'total', 'ids']);
+    assert.equal(rule.description, result.description);
+    assert.containsAllKeys(result, ['ruleName', 'description', 'total', 'ids']);
     assert.equal(result.total, result.ids.length);
   });
 });


### PR DESCRIPTION
Code coverage is low because the test is only run when an env for the subscription id is provided 
closes #36 
closes #34 