### PR TITLE
Rule refactoring

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -10,5 +10,11 @@
     "description": "Get all storage accounts in a subscription",
     "type": "resourceGraph",
     "query": "Resources | where type =~ 'Microsoft.Storage/storageAccounts'"
+  },
+  {
+    "name": "Dummy Mock Rule",
+    "description": "Mocks a multiple rule system",
+    "type": "dummy",
+    "context": {"message": "I don't do anything"}
   }
 ]

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,4 +1,4 @@
-import {ResourceGraphRule, Rule} from './rules';
+import {ResourceGraphRule, Rule, DummyRule} from './rules';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -9,50 +9,39 @@ export interface ScanResult {
   ids: string[];
 }
 
-export type RuleSchema = ResourceGraphRuleSchema;
-
-interface BaseRuleSchema {
-  name: string;
-  description: string;
-  type: string;
-}
-
-interface ResourceGraphRuleSchema extends BaseRuleSchema {
-  type: 'resourceGraph';
-  query: string;
-}
-
 export class Scanner {
-  // filePath was added for testing purposes
-  async scan(queryType: RuleSchema['type'], target: string, filePath?: string) {
-    const rules = this.makeRules(queryType, target, filePath);
-    return Promise.all(rules.map(r => r.execute()));
+  _rules: Rule[] = [];
+
+  async scan(ruleType: Rule['type'], target: string) {
+    if (!this._rules.length) this.loadRulesFromFile();
+    const results = this._executeRules(ruleType, target);
+    return await Promise.all(results);
   }
 
-  private loadRuleData(file = '../../rules.json') {
-    // filePath will eventually be replaced with a url
-    const filePath = path.join(__dirname, file);
-    const data = fs.readFileSync(filePath, 'utf8');
-    const rules: RuleSchema[] = JSON.parse(data);
+  loadRulesFromFile(filePath = '../rules.json') {
+    const absPath = path.join(__dirname, filePath);
+    const data = fs.readFileSync(absPath, 'utf8');
+    const rules: Rule[] = JSON.parse(data);
     return rules;
   }
 
-  private makeRules(
-    queryType: RuleSchema['type'],
-    target: string,
-    filePath?: string
-  ) {
-    const ruleData = this.loadRuleData(filePath);
-    const rules: Rule[] = [];
-    for (const r of ruleData) {
-      switch (queryType) {
-        case 'resourceGraph':
-          if (r.type === 'resourceGraph') {
-            rules.push(new ResourceGraphRule(r, target));
-          }
+  private _executeRules(type: Rule['type'], target: string) {
+    const results: Promise<ScanResult>[] = [];
+    const filteredRules = this._rules.filter(r => r.type === type);
+    for (const r of filteredRules) {
+      switch (r.type) {
+        case 'resourceGraph': {
+          const result = ResourceGraphRule.execute(r, target);
+          results.push(result);
           break;
+        }
+        case 'dummy': {
+          const result = DummyRule.execute(r);
+          results.push(result);
+          break;
+        }
       }
     }
-    return rules;
+    return results;
   }
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,5 +1,5 @@
 import {ResourceGraphRule, Rule, DummyRule} from './rules';
-import * as fs from 'fs';
+import {promises as fsPromises} from 'fs';
 import * as path from 'path';
 
 export interface ScanResult {
@@ -10,19 +10,18 @@ export interface ScanResult {
 }
 
 export class Scanner {
-  _rules: Rule[] = [];
+  private _rules: Rule[] = [];
 
   async scan(ruleType: Rule['type'], target: string) {
-    if (!this._rules.length) this.loadRulesFromFile();
+    if (!this._rules.length) await this.loadRulesFromFile();
     const results = this._executeRules(ruleType, target);
     return await Promise.all(results);
   }
 
-  loadRulesFromFile(filePath = '../rules.json') {
+  async loadRulesFromFile(filePath = '../../rules.json') {
     const absPath = path.join(__dirname, filePath);
-    const data = fs.readFileSync(absPath, 'utf8');
-    const rules: Rule[] = JSON.parse(data);
-    return rules;
+    const data = await fsPromises.readFile(absPath, 'utf8');
+    this._rules = JSON.parse(data);
   }
 
   private _executeRules(type: Rule['type'], target: string) {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,4 +1,10 @@
-import {ResourceGraphRule, Rule, DummyRule} from './rules';
+import {
+  ResourceGraphRule,
+  IResourceGraphRule,
+  Rule,
+  DummyRule,
+  IDummyRule,
+} from './rules';
 import {promises as fsPromises} from 'fs';
 import * as path from 'path';
 
@@ -14,8 +20,7 @@ export class Scanner {
 
   async scan(ruleType: Rule['type'], target: string) {
     if (!this._rules.length) await this.loadRulesFromFile();
-    const results = this._executeRules(ruleType, target);
-    return await Promise.all(results);
+    return this._executeRules(ruleType, target);
   }
 
   async loadRulesFromFile(filePath = '../../rules.json') {
@@ -25,22 +30,17 @@ export class Scanner {
   }
 
   private _executeRules(type: Rule['type'], target: string) {
-    const results: Promise<ScanResult>[] = [];
     const filteredRules = this._rules.filter(r => r.type === type);
-    for (const r of filteredRules) {
-      switch (r.type) {
-        case 'resourceGraph': {
-          const result = ResourceGraphRule.execute(r, target);
-          results.push(result);
-          break;
-        }
-        case 'dummy': {
-          const result = DummyRule.execute(r);
-          results.push(result);
-          break;
-        }
+    switch (type) {
+      case 'resourceGraph': {
+        return ResourceGraphRule.execute(
+          filteredRules as IResourceGraphRule[],
+          target
+        );
+      }
+      case 'dummy': {
+        return DummyRule.execute(filteredRules as IDummyRule[]);
       }
     }
-    return results;
   }
 }

--- a/test/azure/rules.spec.ts
+++ b/test/azure/rules.spec.ts
@@ -1,6 +1,5 @@
 import {assert} from 'chai';
-import {ResourceGraphRule} from '../../src/rules';
-import {RuleSchema} from '../../src/scanner';
+import {Rule, ResourceGraphRule} from '../../src/rules';
 import {subscriptionId} from '.';
 
 describe('Resource Graph Rule', function () {
@@ -12,27 +11,16 @@ describe('Resource Graph Rule', function () {
       "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'";
     const name = 'Dummy Rule';
     const description = 'Intentional bad query';
-    const rule: RuleSchema = {
+    const rule: Rule = {
       name,
       query,
       description,
       type: 'resourceGraph',
     };
-    const rgr = new ResourceGraphRule(rule, subscriptionId);
-
-    try {
-      const result = await rgr.execute();
-      assert.equal(rule.name, result.ruleName);
-      assert.equal(rule.description, result.description);
-      assert.containsAllKeys(result, [
-        'ruleName',
-        'description',
-        'total',
-        'ids',
-      ]);
-      assert.equal(result.total, 0);
-    } catch (err) {
-      throw new Error(err);
-    }
+    const result = await ResourceGraphRule.execute(rule, subscriptionId);
+    assert.equal(rule.name, result.ruleName);
+    assert.equal(rule.description, result.description);
+    assert.containsAllKeys(result, ['ruleName', 'description', 'total', 'ids']);
+    assert.equal(result.total, 0);
   });
 });

--- a/test/azure/rules.spec.ts
+++ b/test/azure/rules.spec.ts
@@ -17,10 +17,17 @@ describe('Resource Graph Rule', function () {
       description,
       type: 'resourceGraph',
     };
-    const result = await ResourceGraphRule.execute(rule, subscriptionId);
-    assert.equal(rule.name, result.ruleName);
-    assert.equal(rule.description, result.description);
-    assert.containsAllKeys(result, ['ruleName', 'description', 'total', 'ids']);
-    assert.equal(result.total, 0);
+    const results = await ResourceGraphRule.execute([rule], subscriptionId);
+    for (const result of results) {
+      assert.equal(rule.name, result.ruleName);
+      assert.equal(rule.description, result.description);
+      assert.containsAllKeys(result, [
+        'ruleName',
+        'description',
+        'total',
+        'ids',
+      ]);
+      assert.equal(result.total, 0);
+    }
   });
 });

--- a/test/azure/scanner.spec.ts
+++ b/test/azure/scanner.spec.ts
@@ -7,18 +7,10 @@ describe('Scanner', function () {
   this.timeout(8000);
   it('can load and execute resource graph rules from a JSON file', async () => {
     const scanner = new Scanner();
-    try {
-      const results = await scanner.scan(
-        'resourceGraph',
-        subscriptionId,
-        '../test/rules.json'
-      );
-      results.forEach(r => {
-        assert.containsAllKeys(r, ['ruleName', 'description', 'total', 'ids']);
-        assert.equal(r.total, 0);
-      });
-    } catch (err) {
-      throw new Error(err);
-    }
+    const results = await scanner.scan('resourceGraph', subscriptionId);
+    results.forEach(r => {
+      assert.containsAllKeys(r, ['ruleName', 'description', 'total', 'ids']);
+      assert.equal(r.total, 0);
+    });
   });
 });

--- a/test/azure/scanner.spec.ts
+++ b/test/azure/scanner.spec.ts
@@ -7,8 +7,16 @@ describe('Scanner', function () {
   this.timeout(8000);
   it('can load and execute resource graph rules from a JSON file', async () => {
     const scanner = new Scanner();
-    const results = await scanner.scan('resourceGraph', subscriptionId);
-    results.forEach(r => {
+    await scanner.loadRulesFromFile('../test/rules.json');
+    const rgResults = await scanner.scan('resourceGraph', subscriptionId);
+    assert.equal(rgResults.length, 1);
+    rgResults.forEach(r => {
+      assert.containsAllKeys(r, ['ruleName', 'description', 'total', 'ids']);
+      assert.equal(r.total, 0);
+    });
+    const dummyResults = await scanner.scan('dummy', '');
+    assert.equal(dummyResults.length, 2);
+    dummyResults.forEach(r => {
       assert.containsAllKeys(r, ['ruleName', 'description', 'total', 'ids']);
       assert.equal(r.total, 0);
     });

--- a/test/rules.json
+++ b/test/rules.json
@@ -4,5 +4,17 @@
     "description": "Should return no results",
     "type": "resourceGraph",
     "query": "Resources | where type =~ 'Microsoft.Network/virtualNetworks2'"
+  },
+  {
+    "name": "Mock Dummy Rule",
+    "description": "mocks a multiple rule system",
+    "type": "dummy",
+    "context": {}
+  },
+  {
+    "name": "Mock Dummy Rule 2",
+    "description": "mocks a multiple rule system",
+    "type": "dummy",
+    "context": {}
   }
 ]


### PR DESCRIPTION
closes #43 

- Rules :
    - refactors rules to use static execute methods
    -  rule execute methods take a rule interface array and a target and returns a promise scan result[]
    - adds a dummy rule to mock a multiple rule system
- Scanner : 
    - scanner class can load different rules for testing
    - rules stay loaded in the scanner class so different rule types can be run again without reloading all the rules again
