### PR TITLE
Scan command base

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ npm install -g aza
 $ aza COMMAND
 running command...
 $ aza (-v|--version|version)
-aza/0.0.0 linux-x64 node-v14.15.5
+aza/0.0.0 win32-x64 node-v14.15.4
 $ aza --help [COMMAND]
 USAGE
   $ aza COMMAND
@@ -22,6 +22,7 @@ USAGE
 
 <!-- commands -->
 * [`aza hello [FILE]`](#aza-hello-file)
+* [`aza scan`](#aza-scan)
 
 ## `aza hello [FILE]`
 
@@ -39,6 +40,34 @@ OPTIONS
 EXAMPLE
   $ ./bin/run hello
   hello world from ./src/hello.ts!
+```
+
+## `aza scan`
+
+Scans Azure resources for potential configuration issues
+
+```
+USAGE
+  $ aza scan
+
+OPTIONS
+  -d, --dummy        runs dummy rules to mock multi rule system
+  -f, --file=file    JSON rules file path
+  -h, --help         show CLI help
+  -s, --scope=scope  Azure subscription id to scan
+  -v, --verbose      prints all results
+  --debug            prints debugging logs
+
+EXAMPLE
+  $ aza scan --scope <SCOPE>
+       [rule-name]
+           [✓ | ❌][rule-description]     
+           Resources:
+                   [resource-ids]
+
+       [total-passing]
+       [total-failing]
+       [total-rules-scanned]
 ```
 <!-- commandsstop -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -957,8 +957,7 @@
     "@oclif/screen": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
-      "dev": true
+      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw=="
     },
     "@oclif/test": {
       "version": "1.2.8",
@@ -1315,7 +1314,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "dev": true,
       "requires": {
         "type-fest": "^0.11.0"
       },
@@ -1323,8 +1321,7 @@
         "type-fest": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
         }
       }
     },
@@ -1344,8 +1341,7 @@
     "ansicolors": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
-      "dev": true
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
     },
     "anymatch": {
       "version": "3.1.1",
@@ -1398,7 +1394,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1697,7 +1692,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
-      "dev": true,
       "requires": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -1796,7 +1790,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
       "integrity": "sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==",
-      "dev": true,
       "requires": {
         "colors": "^1.1.2",
         "string-width": "^4.2.0"
@@ -1805,20 +1798,17 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
           "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -1829,7 +1819,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -1840,7 +1829,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.5.1.tgz",
       "integrity": "sha512-t3DT1U1C3rArLGYLpKa3m9dr/8uKZRI8HRm/rXKL7UTjm4c+Yd9zHNWg1tP8uaJkUbhmvx5SQHwb3VWpPUVdHQ==",
-      "dev": true,
       "requires": {
         "@oclif/command": "^1.6.0",
         "@oclif/errors": "^1.2.1",
@@ -1873,14 +1861,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "clean-stack": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
           "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
-          "dev": true,
           "requires": {
             "escape-string-regexp": "4.0.0"
           }
@@ -1888,20 +1874,17 @@
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "semver": {
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -1910,7 +1893,6 @@
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
           "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -1921,7 +1903,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -1929,8 +1910,7 @@
         "tslib": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -2023,8 +2003,7 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2593,8 +2572,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -2694,8 +2672,7 @@
     "extract-stack": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
-      "dev": true
+      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -3279,8 +3256,7 @@
     "hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
-      "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
-      "dev": true
+      "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -3562,8 +3538,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -3671,7 +3646,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3901,8 +3875,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -4319,8 +4292,7 @@
     "natural-orderby": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
-      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
-      "dev": true
+      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q=="
     },
     "ncp": {
       "version": "2.0.0",
@@ -4331,8 +4303,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nock": {
       "version": "13.0.7",
@@ -4587,10 +4558,9 @@
       "optional": true
     },
     "object-treeify": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.31.tgz",
-      "integrity": "sha512-kt2UuyHDTH+J6w0pv2c+3uuEApGuwgfjWogbqPWAvk4nOM/T3No0SzDtp6CuJ/XBUy//nFNuerb8ms7CqjD9Tw==",
-      "dev": true
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
+      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="
     },
     "once": {
       "version": "1.4.0",
@@ -4746,7 +4716,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
       "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
-      "dev": true,
       "requires": {
         "ansi-escapes": "^3.1.0",
         "cross-spawn": "^6.0.5"
@@ -4755,14 +4724,12 @@
         "ansi-escapes": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-          "dev": true
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
         },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
@@ -4774,14 +4741,12 @@
         "path-key": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
@@ -4789,14 +4754,12 @@
         "shebang-regex": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-          "dev": true
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -5374,7 +5337,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
-      "dev": true,
       "requires": {
         "esprima": "~4.0.0"
       }
@@ -5777,8 +5739,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -5910,7 +5871,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
       "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "@azure/arm-resourcegraph": "^3.0.0",
     "@azure/identity": "^1.2.3",
     "@azure/ms-rest-js": "^2.2.3",
-    "@oclif/command": "^1.8.0"
+    "@oclif/command": "^1.8.0",
+    "chalk": "^4.1.0",
+    "cli-ux": "^5.5.1"
   },
   "oclif": {
     "commands": "./build/src/commands",

--- a/rules.json
+++ b/rules.json
@@ -2,19 +2,19 @@
   {
     "name": "Mock Rule - Get VMs",
     "description": "Get all virtual Machines in a subscription",
-    "type": "resourceGraph",
+    "type": "ResourceGraph",
     "query": "Resources | where type =~ 'Microsoft.Compute/virtualMachines'"
   },
   {
     "name": "Mock Rule - Get Storage Accounts",
     "description": "Get all storage accounts in a subscription",
-    "type": "resourceGraph",
+    "type": "ResourceGraph",
     "query": "Resources | where type =~ 'Microsoft.Storage/storageAccounts'"
   },
   {
     "name": "Dummy Mock Rule",
     "description": "Mocks a multiple rule system",
-    "type": "dummy",
+    "type": "Dummy",
     "context": {"message": "I don't do anything"}
   }
 ]

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -132,7 +132,6 @@ export default class Scan extends Command {
       this.error('Command scan expects a Flag');
     }
 
-    console.log(flags.file);
     await scanner.loadRulesFromFile(flags.file);
     cli.action.start('Scanning');
     const results = await scanner.scan(target);

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -68,19 +68,18 @@ export default class Scan extends Command {
   }
 
   private printResult(result: ScanResult) {
-    const redX = '\u274c';
-    const greenCheck = chalk.green('\u2713');
     const totalResources = result.resourceIds.length;
-    const description = chalk.grey(result.description);
     this.log(result.ruleName, {bold: true, indent: 4});
     if (result.total) {
-      this.log(`${redX} ${description}`, {indent: 6});
+      this.log(`❌ ${result.description}`, {color: 'grey', indent: 6});
       this.log(`Resources (${totalResources}):`, {indent: 6});
       for (const id of result.resourceIds) {
         this.log(id, {indent: 8});
       }
     } else {
-      this.log(`${greenCheck} ${description}`, {indent: 6});
+      this.log(`${chalk.green('✓')} ${chalk.grey(result.description)}`, {
+        indent: 6,
+      });
     }
     this.log('');
   }

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,0 +1,142 @@
+import {Command, flags} from '@oclif/command';
+import {Scanner, ScanResult} from '../scanner';
+import {ResourceGraphTarget, DummyTarget, Target, RuleType} from '../rules';
+import cli from 'cli-ux';
+import chalk = require('chalk');
+
+interface LogOptions {
+  color?: string;
+  indent?: number;
+  bold?: boolean;
+}
+
+export default class Scan extends Command {
+  private isDebugMode = false;
+  private isVerbose = false;
+
+  static description =
+    'Scans Azure resources for potential configuration issues';
+
+  static examples = [
+    `$ aza scan --scope <SCOPE>
+    [rule-name]
+        [✓ | ❌][rule-description]     
+        Resources:
+                [resource-ids]
+
+    [total-passing]
+    [total-failing]
+    [total-rules-scanned]   
+`,
+  ];
+
+  static flags = {
+    help: flags.help({char: 'h'}),
+    scope: flags.string({
+      char: 's',
+      description: 'Azure subscription id to scan',
+    }),
+    dummy: flags.boolean({
+      char: 'd',
+      description: 'runs dummy rules to mock multi rule system',
+    }),
+    file: flags.string({
+      char: 'f',
+      description: 'JSON rules file path',
+    }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'prints all results',
+    }),
+    debug: flags.boolean({
+      description: 'prints debugging logs',
+    }),
+  };
+
+  public log(message: string, options?: LogOptions) {
+    let formattedMessage = message;
+    if (options?.color) {
+      formattedMessage = chalk.keyword(options.color)(formattedMessage);
+    }
+    if (options?.indent) {
+      formattedMessage = ' '.repeat(options.indent) + formattedMessage;
+    }
+    if (options?.bold) {
+      formattedMessage = chalk.bold(formattedMessage);
+    }
+    super.log(formattedMessage);
+  }
+
+  private printResult(result: ScanResult) {
+    const redX = '\u274c';
+    const greenCheck = chalk.green('\u2713');
+    const totalResources = result.resourceIds.length;
+    const description = chalk.grey(result.description);
+    this.log(result.ruleName, {bold: true, indent: 4});
+    if (result.total) {
+      this.log(`${redX} ${description}`, {indent: 6});
+      this.log(`Resources (${totalResources}):`, {indent: 6});
+      for (const id of result.resourceIds) {
+        this.log(id, {indent: 8});
+      }
+    } else {
+      this.log(`${greenCheck} ${description}`, {indent: 6});
+    }
+    this.log('');
+  }
+
+  private printSummary(results: ScanResult[]) {
+    const total = results.length;
+    const totalPassed = results.filter(r => !r.total).length;
+    const totalFailed = total - totalPassed;
+    this.log(`${totalPassed} passing`, {
+      color: 'green',
+    });
+    if (this.isVerbose) {
+      this.log(`${totalFailed} failing`, {
+        color: 'red',
+      });
+    }
+    this.log(`${total} scanned`);
+  }
+
+  private print(results: ScanResult[]) {
+    for (const r of results) {
+      if (this.isVerbose || r.total) {
+        this.printResult(r);
+      }
+    }
+    this.printSummary(results);
+  }
+
+  async catch(error: Error) {
+    if (this.isDebugMode) console.log(error);
+    throw error;
+  }
+
+  async run() {
+    const {flags} = this.parse(Scan);
+    const scanner = new Scanner();
+    let target: Target;
+
+    if (flags.verbose) this.isVerbose = true;
+    if (flags.debug) this.isDebugMode = true;
+    if (flags.scope) {
+      target = {
+        type: RuleType.ResourceGraph,
+        subscriptionId: flags.scope,
+      } as ResourceGraphTarget;
+    } else if (flags.dummy) {
+      target = {type: RuleType.Dummy, context: {}} as DummyTarget;
+    } else {
+      this.error('Command scan expects a Flag');
+    }
+
+    console.log(flags.file);
+    await scanner.loadRulesFromFile(flags.file);
+    cli.action.start('Scanning');
+    const results = await scanner.scan(target);
+    cli.action.stop();
+    this.print(results);
+  }
+}

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -68,11 +68,10 @@ export default class Scan extends Command {
   }
 
   private printResult(result: ScanResult) {
-    const totalResources = result.resourceIds.length;
     this.log(result.ruleName, {bold: true, indent: 4});
     if (result.total) {
       this.log(`❌ ${result.description}`, {color: 'grey', indent: 6});
-      this.log(`Resources (${totalResources}):`, {indent: 6});
+      this.log(`Resources (${result.total}):`, {indent: 6});
       for (const id of result.resourceIds) {
         this.log(id, {indent: 8});
       }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,9 +1,12 @@
 import {
+  ResourceGraphExecutor,
   ResourceGraphRule,
-  IResourceGraphRule,
+  ResourceGraphTarget,
   Rule,
+  DummyRuleExecutor,
   DummyRule,
-  IDummyRule,
+  Target,
+  RuleType,
 } from './rules';
 import {promises as fsPromises} from 'fs';
 import * as path from 'path';
@@ -12,34 +15,34 @@ export interface ScanResult {
   ruleName: string;
   description: string;
   total: number;
-  ids: string[];
+  resourceIds: string[];
 }
 
 export class Scanner {
-  private _rules: Rule[] = [];
+  rules: Rule[] = [];
 
-  async scan(ruleType: Rule['type'], target: string) {
-    if (!this._rules.length) await this.loadRulesFromFile();
-    return this._executeRules(ruleType, target);
+  async scan(target: Target) {
+    if (!this.rules.length) await this.loadRulesFromFile();
+    return this.executeRules(target);
   }
 
-  async loadRulesFromFile(filePath = '../../rules.json') {
+  async loadRulesFromFile(filePath = '../rules.json') {
     const absPath = path.join(__dirname, filePath);
     const data = await fsPromises.readFile(absPath, 'utf8');
-    this._rules = JSON.parse(data);
+    this.rules = JSON.parse(data);
   }
 
-  private _executeRules(type: Rule['type'], target: string) {
-    const filteredRules = this._rules.filter(r => r.type === type);
-    switch (type) {
-      case 'resourceGraph': {
-        return ResourceGraphRule.execute(
-          filteredRules as IResourceGraphRule[],
-          target
+  private executeRules(target: Target) {
+    const filteredRules = this.rules.filter(r => r.type === target.type);
+    switch (target.type) {
+      case RuleType.ResourceGraph: {
+        return ResourceGraphExecutor.execute(
+          filteredRules as ResourceGraphRule[],
+          target as ResourceGraphTarget
         );
       }
-      case 'dummy': {
-        return DummyRule.execute(filteredRules as IDummyRule[]);
+      case RuleType.Dummy: {
+        return DummyRuleExecutor.execute(filteredRules as DummyRule[]);
       }
     }
   }

--- a/test/azure/rules.spec.ts
+++ b/test/azure/rules.spec.ts
@@ -1,5 +1,10 @@
 import {assert} from 'chai';
-import {Rule, ResourceGraphRule} from '../../src/rules';
+import {
+  ResourceGraphRule,
+  ResourceGraphExecutor,
+  ResourceGraphTarget,
+  RuleType,
+} from '../../src/rules';
 import {subscriptionId} from '.';
 
 describe('Resource Graph Rule', function () {
@@ -9,15 +14,19 @@ describe('Resource Graph Rule', function () {
   it('can execute a resource graph rule and return a scan result', async () => {
     const query =
       "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'";
-    const name = 'Dummy Rule';
+    const name = 'test-rule';
     const description = 'Intentional bad query';
-    const rule: Rule = {
+    const rule: ResourceGraphRule = {
       name,
       query,
       description,
-      type: 'resourceGraph',
+      type: RuleType.ResourceGraph,
     };
-    const results = await ResourceGraphRule.execute([rule], subscriptionId);
+    const target: ResourceGraphTarget = {
+      type: RuleType.ResourceGraph,
+      subscriptionId,
+    };
+    const results = await ResourceGraphExecutor.execute([rule], target);
     for (const result of results) {
       assert.equal(rule.name, result.ruleName);
       assert.equal(rule.description, result.description);
@@ -25,9 +34,9 @@ describe('Resource Graph Rule', function () {
         'ruleName',
         'description',
         'total',
-        'ids',
+        'resourceIds',
       ]);
-      assert.equal(result.total, 0);
+      assert.isAtLeast(result.total, 0);
     }
   });
 });

--- a/test/azure/rules.spec.ts
+++ b/test/azure/rules.spec.ts
@@ -8,8 +8,8 @@ import {
 import {subscriptionId} from '.';
 
 describe('Resource Graph Rule', function () {
-  this.slow(5000);
-  this.timeout(8000);
+  this.slow(6000);
+  this.timeout(10000);
 
   it('can execute a resource graph rule and return a scan result', async () => {
     const query =

--- a/test/azure/scan.spec.ts
+++ b/test/azure/scan.spec.ts
@@ -1,0 +1,61 @@
+import {expect, test} from '@oclif/test';
+import {resourceGroup, subscriptionId} from '.';
+
+describe('Scan Integration Tests', function () {
+  this.slow(4000);
+  this.timeout(6000);
+  test
+    .stdout()
+    .command([
+      'scan',
+      '--scope',
+      subscriptionId,
+      '--file',
+      '../test/rules.json',
+    ])
+    .it('runs scan --scope [subscriptionId] --file ../test/rules.json', ctx => {
+      expect(ctx.stdout).to.not.contain('    bad-query\n');
+      expect(ctx.stdout).to.not.contain(
+        '      ✓ Gets all vnets in a subscription\n'
+      );
+      expect(ctx.stdout).to.contain('    get-vnets\n');
+      expect(ctx.stdout).to.contain(
+        '      ❌ Gets all vnets in a subscription\n'
+      );
+      expect(ctx.stdout).to.contain('      Resources');
+      expect(ctx.stdout).to.contain(
+        `        /subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Network/virtualNetworks/vnet`
+      );
+      expect(ctx.stdout).to.contain('1 passing');
+      expect(ctx.stdout).to.not.contain('failing');
+      expect(ctx.stdout).to.contain('2 scanned');
+    });
+  test
+    .stdout()
+    .command([
+      'scan',
+      '--scope',
+      subscriptionId,
+      '--file',
+      '../test/rules.json',
+      '-v',
+    ])
+    .it(
+      'runs scan --scope [subscriptionId] --file ../test/rules.json --verbose',
+      ctx => {
+        expect(ctx.stdout).to.contain('    bad-query\n');
+        expect(ctx.stdout).to.contain('      ✓ Should return no results\n');
+        expect(ctx.stdout).to.contain('    get-vnets\n');
+        expect(ctx.stdout).to.contain(
+          '      ❌ Gets all vnets in a subscription\n'
+        );
+        expect(ctx.stdout).to.contain('      Resources');
+        expect(ctx.stdout).to.contain(
+          `        /subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Network/virtualNetworks/vnet`
+        );
+        expect(ctx.stdout).to.contain('1 passing');
+        expect(ctx.stdout).to.contain('1 failing');
+        expect(ctx.stdout).to.contain('2 scanned');
+      }
+    );
+});

--- a/test/azure/scanner.spec.ts
+++ b/test/azure/scanner.spec.ts
@@ -1,24 +1,32 @@
 import {assert} from 'chai';
 import {Scanner} from '../../src/scanner';
-import {subscriptionId} from '.';
+import {resourceGroup, subscriptionId} from '.';
+import {ResourceGraphTarget, RuleType} from '../../src/rules';
 
 describe('Scanner', function () {
   this.slow(5000);
   this.timeout(8000);
   it('can load and execute resource graph rules from a JSON file', async () => {
+    const rgTarget: ResourceGraphTarget = {
+      type: RuleType.ResourceGraph,
+      subscriptionId,
+    };
     const scanner = new Scanner();
     await scanner.loadRulesFromFile('../test/rules.json');
-    const rgResults = await scanner.scan('resourceGraph', subscriptionId);
-    assert.equal(rgResults.length, 1);
+    const rgResults = await scanner.scan(rgTarget);
+    const re = new RegExp(`/resourceGroups/${resourceGroup}`);
+    assert.isAtLeast(rgResults.length, 2);
     rgResults.forEach(r => {
-      assert.containsAllKeys(r, ['ruleName', 'description', 'total', 'ids']);
-      assert.equal(r.total, 0);
-    });
-    const dummyResults = await scanner.scan('dummy', '');
-    assert.equal(dummyResults.length, 2);
-    dummyResults.forEach(r => {
-      assert.containsAllKeys(r, ['ruleName', 'description', 'total', 'ids']);
-      assert.equal(r.total, 0);
+      assert.containsAllKeys(r, [
+        'ruleName',
+        'description',
+        'total',
+        'resourceIds',
+      ]);
+      if (r.ruleName === 'get-vnets') {
+        const groupResources = r.resourceIds.filter(id => re.test(id));
+        assert.equal(groupResources.length, 1);
+      }
     });
   });
 });

--- a/test/rules.json
+++ b/test/rules.json
@@ -1,20 +1,26 @@
 [
   {
-    "name": "Mock Rule - Intentional Bad Query",
+    "name": "bad-query",
     "description": "Should return no results",
-    "type": "resourceGraph",
+    "type": "ResourceGraph",
     "query": "Resources | where type =~ 'Microsoft.Network/virtualNetworks2'"
   },
   {
-    "name": "Mock Dummy Rule",
+    "name": "get-vnets",
+    "description": "Gets all vnets in a subscription",
+    "type": "ResourceGraph",
+    "query": "Resources | where type =~ 'Microsoft.Network/virtualNetworks'"
+  },
+  {
+    "name": "dummy-rule-1",
     "description": "mocks a multiple rule system",
-    "type": "dummy",
+    "type": "Dummy",
     "context": {}
   },
   {
-    "name": "Mock Dummy Rule 2",
+    "name": "dummy-rule-2",
     "description": "mocks a multiple rule system",
-    "type": "dummy",
+    "type": "Dummy",
     "context": {}
   }
 ]

--- a/test/unit/commands/hello.spec.ts
+++ b/test/unit/commands/hello.spec.ts
@@ -1,6 +1,8 @@
 import {expect, test} from '@oclif/test';
 
-describe('hello', () => {
+describe('hello', function () {
+  this.slow(3000);
+  this.timeout(5000);
   test
     .stdout()
     .command(['hello'])

--- a/test/unit/commands/scan.spec.ts
+++ b/test/unit/commands/scan.spec.ts
@@ -27,4 +27,14 @@ describe('Scan Unit Tests', function () {
       expect(ctx.stdout).to.not.contain('0 failing');
       expect(ctx.stdout).to.contain('2 scanned');
     });
+  test
+    .stdout()
+    .command(['scan'])
+    .exit(2)
+    .it(
+      'exits with error code 2 when running scan without a flag',
+      ({stdout}) => {
+        expect(stdout).to.equal('');
+      }
+    );
 });

--- a/test/unit/commands/scan.spec.ts
+++ b/test/unit/commands/scan.spec.ts
@@ -31,10 +31,11 @@ describe('Scan Unit Tests', function () {
     .stdout()
     .command(['scan'])
     .exit(2)
-    .it(
-      'exits with error code 2 when running scan without a flag',
-      ({stdout}) => {
-        expect(stdout).to.equal('');
-      }
-    );
+    .it('exits with error code 2 when running scan without a flag');
+  test
+    .stdout()
+    .stderr()
+    .command(['scan', '--scope'])
+    .exit(2)
+    .it('exits with error code 2 when running scan --scope without a value');
 });

--- a/test/unit/commands/scan.spec.ts
+++ b/test/unit/commands/scan.spec.ts
@@ -1,0 +1,30 @@
+import {expect, test} from '@oclif/test';
+
+describe('Scan Unit Tests', function () {
+  this.slow(3000);
+  this.timeout(5000);
+  test
+    .stdout()
+    .command(['scan', '--dummy', '--file', '../test/rules.json', '--verbose'])
+    .it('runs scan --dummy --file ../test/rules.json --verbose', ctx => {
+      expect(ctx.stdout).to.contain(
+        '    dummy-rule-1\n      ✓ mocks a multiple rule system\n'
+      );
+      expect(ctx.stdout).to.contain(
+        '    dummy-rule-2\n      ✓ mocks a multiple rule system\n'
+      );
+      expect(ctx.stdout).to.contain('2 passing');
+      expect(ctx.stdout).to.contain('0 failing');
+      expect(ctx.stdout).to.contain('2 scanned');
+    });
+  test
+    .stdout()
+    .command(['scan', '-d', '-f', '../test/rules.json'])
+    .it('runs scan -d -f ../test/rules.json', ctx => {
+      expect(ctx.stdout).to.not.contain('dummy-rule-1');
+      expect(ctx.stdout).to.not.contain('dummy-rule-2');
+      expect(ctx.stdout).to.contain('2 passing');
+      expect(ctx.stdout).to.not.contain('0 failing');
+      expect(ctx.stdout).to.contain('2 scanned');
+    });
+});

--- a/test/unit/scanner.spec.ts
+++ b/test/unit/scanner.spec.ts
@@ -1,0 +1,36 @@
+import {assert} from 'chai';
+import {DummyTarget, RuleType} from '../../src/rules';
+import {Scanner} from '../../src/scanner';
+
+describe('Scanner', function () {
+  this.slow(5000);
+  this.timeout(8000);
+  it('can load rules from a JSON file', async () => {
+    const scanner = new Scanner();
+    await scanner.loadRulesFromFile('../test/rules.json');
+    assert.isAtLeast(scanner.rules.length, 4);
+    for (const r of scanner.rules) {
+      assert.containsAllKeys(r, ['name', 'description', 'type']);
+    }
+  });
+
+  it('can execute a dummy rule and return a scan result', async () => {
+    const target: DummyTarget = {
+      type: RuleType.Dummy,
+      context: {},
+    };
+    const scanner = new Scanner();
+    await scanner.loadRulesFromFile('../test/rules.json');
+    const results = await scanner.scan(target);
+    assert.equal(results.length, 2);
+    for (const r of results) {
+      assert.containsAllKeys(r, [
+        'ruleName',
+        'description',
+        'total',
+        'resourceIds',
+      ]);
+      assert.equal(r.total, 0);
+    }
+  });
+});


### PR DESCRIPTION
closes #45 
closes #48 

- scan.ts - can run Resource Graph rules from a single subscription
    - Flags
        - --scope, -s=subscriptionId
            - scans resource graph rules
        - --dummy, -d 
            - scans dummy rules
        - --file, -f=filePath
            - loads rules from file path
        - --verbose, -v
        - --debug
    - Formats and prints results to console 
- scanner.ts      
    - scan method accepts a target and filters rules bases on the type     
- rules.ts
    - adds RuleType enum 
    - adds type Target
- rules.json
    - update to rule type naming convention to use with enum   