### PR TITLE
Multi scope

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,4 @@ AZA_TEST_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
 
 # (optional) Resource group to be used for integration tests
 #AZA_TEST_RESOURCE_GROUP=
+#AZA_TEST_RESOURCE_GROUP_2=

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ on:
       - main
     types: [opened]
   issue_comment:
-      types: [created]  
+      types: [created, updated]  
 
 jobs: 
   build: 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,6 +56,7 @@ jobs:
         trigger: '@create-executables'
 
     - name: Create standalone executables
+      if: steps.check.outputs.triggered == 'true'          
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,10 +53,10 @@ jobs:
       uses: khan/pull-request-comment-trigger@master
       id: check
       with:
-        trigger: '@create-executables'
+        trigger: '@do-not-create-executables'
 
     - name: Create standalone executables
-      if: steps.check.outputs.triggered == 'true'          
+      if: ${{ github.event_name != 'push' && steps.check.outputs.triggered == 'false'}}        
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,9 +48,9 @@ jobs:
 
     - name: Create standalone executables
       uses: khan/pull-request-comment-trigger@master
-            id: check
-            with:
-              trigger: '@do-not-create-executables'
+      id: check
+      with:
+        trigger: '@do-not-create-executables'
 
       if: steps.check.outputs.triggered == 'true'          
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,6 +50,7 @@ jobs:
           pkg-
 
     - name: Trigger standalone executables on pull request comment 
+      if: ${{ github.event_name == 'pull_request' }}
       uses: khan/pull-request-comment-trigger@master
       id: check
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,9 +54,9 @@ jobs:
       uses: khan/pull-request-comment-trigger@master
       id: check
       with:
-        trigger: 'do-not-create-executables'
+        trigger: 'create-executables'
     - name: Create standalone executables
-      if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'false'}}        
+      if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'true'}}        
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,11 +54,11 @@ jobs:
       uses: khan/pull-request-comment-trigger@master
       id: check
       with:
-        trigger: '@do-not-create-executables'
+        trigger: 'do-not-create-executables'
 
     - name: Testing trigger
       if: steps.check.outputs.triggered == 'true'
-      run: 'echo ${{ github.event.comment.body }}'      
+      run: 'echo ${{ github.event.comment_body }}'      
 
     - name: Create standalone executables
       if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'true'}}        

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,9 +5,6 @@ on:
   pull_request: 
     branches: 
       - main
-    types: [opened]
-  issue_comment:
-      types: [created]  
 
 jobs: 
   build: 
@@ -49,14 +46,7 @@ jobs:
         restore-keys: |
           pkg-
 
-    - name: Trigger standalone executables on pull request comment 
-      uses: khan/pull-request-comment-trigger@master
-      id: check
-      with:
-        trigger: '@create-executables'
-
     - name: Create standalone executables
-      if: steps.check.outputs.triggered == 'true'          
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,7 @@ jobs:
         trigger: '@do-not-create-executables'
 
     - name: Create standalone executables
-      if: ${{ github.event_name != 'push' && steps.check.outputs.triggered == 'false'}}        
+      if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'false'}}        
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,6 +56,10 @@ jobs:
       with:
         trigger: '@do-not-create-executables'
 
+    - name: Testing trigger
+      if: steps.check.outputs.triggered == 'true'
+      run: 'echo ${{ github.event.comment.body }}'      
+
     - name: Create standalone executables
       if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'true'}}        
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,6 +47,12 @@ jobs:
           pkg-
 
     - name: Create standalone executables
+      uses: khan/pull-request-comment-trigger@master
+            id: check
+            with:
+              trigger: '@do-not-create-executables'
+
+      if: steps.check.outputs.triggered == 'true'          
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,6 +5,9 @@ on:
   pull_request: 
     branches: 
       - main
+    types: [opened]
+  issue_comment:
+      types: [created]  
 
 jobs: 
   build: 
@@ -48,6 +51,7 @@ jobs:
 
     - name: Trigger standalone executables on pull request comment 
       uses: khan/pull-request-comment-trigger@master
+      id: check
       with:
         trigger: '@create-executables'
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,12 +46,13 @@ jobs:
         restore-keys: |
           pkg-
 
-    - name: Create standalone executables
-      uses: khan/pull-request-comment-trigger@master
+    - name: Trigger standalone executables on pull request comment 
+    - uses: khan/pull-request-comment-trigger@master
       id: check
       with:
         trigger: '@do-not-create-executables'
 
+    - name: Create standalone executables
       if: steps.check.outputs.triggered == 'true'          
       run: |
         npm ci --production --ignore-scripts

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,7 +50,7 @@ jobs:
       uses: khan/pull-request-comment-trigger@master
       id: check
       with:
-        trigger: '@do-not-create-executables'
+        trigger: '@create-executables'
 
     - name: Create standalone executables
       if: steps.check.outputs.triggered == 'true'          

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
           pkg-
 
     - name: Trigger standalone executables on pull request comment 
-    - uses: khan/pull-request-comment-trigger@master
+      uses: khan/pull-request-comment-trigger@master
       id: check
       with:
         trigger: '@do-not-create-executables'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,7 +57,7 @@ jobs:
         trigger: '@do-not-create-executables'
 
     - name: Create standalone executables
-      if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'false'}}        
+      if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'true'}}        
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,6 @@ jobs:
 
     - name: Trigger standalone executables on pull request comment 
       uses: khan/pull-request-comment-trigger@master
-      id: check
       with:
         trigger: '@create-executables'
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,13 +55,8 @@ jobs:
       id: check
       with:
         trigger: 'do-not-create-executables'
-
-    - name: Testing trigger
-      if: steps.check.outputs.triggered == 'true'
-      run: 'echo ${{ github.event.comment_body }}'      
-
     - name: Create standalone executables
-      if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'true'}}        
+      if: ${{ github.event_name == 'pull_request' && steps.check.outputs.triggered == 'false'}}        
       run: |
         npm ci --production --ignore-scripts
         npm i -g pkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,6 +5,9 @@ on:
   pull_request: 
     branches: 
       - main
+    types: [opened]
+  issue_comment:
+      types: [created]  
 
 jobs: 
   build: 
@@ -45,6 +48,12 @@ jobs:
         key: pkg-${{ hashFiles('**/package.json') }}
         restore-keys: |
           pkg-
+
+    - name: Trigger standalone executables on pull request comment 
+      uses: khan/pull-request-comment-trigger@master
+      id: check
+      with:
+        trigger: '@create-executables'
 
     - name: Create standalone executables
       run: |

--- a/README.md
+++ b/README.md
@@ -59,4 +59,3 @@ To run the integration tests:
 
 - Copy `.env.template` to `.env` and fill with your desired values
 - `npm test`
-

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ USAGE
 OPTIONS
   -d, --dummy        runs dummy rules to mock multi rule system
   -f, --file=file    JSON rules file path
+  -g, --group=group  Azure resource groups to scan
   -h, --help         show CLI help
   -s, --scope=scope  Azure subscription id to scan
   -v, --verbose      prints all results

--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ To run the integration tests:
 
 - Copy `.env.template` to `.env` and fill with your desired values
 - `npm test`
+

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -31,6 +31,13 @@ export default class Scan extends Command {
     scope: flags.string({
       char: 's',
       description: 'Azure subscription id to scan',
+      multiple: true,
+    }),
+    groups: flags.string({
+      char: 'g',
+      description: 'Azure resource groups to scan',
+      multiple: true,
+      dependsOn: ['scope'],
     }),
     dummy: flags.boolean({
       char: 'd',
@@ -107,7 +114,8 @@ export default class Scan extends Command {
     if (flags.scope) {
       target = {
         type: RuleType.ResourceGraph,
-        subscriptionId: flags.scope,
+        subscriptionIds: flags.scope,
+        groupNames: flags.groups,
         credential: new DefaultAzureCredential(),
       };
     } else if (flags.dummy) {

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@oclif/command';
 import {Scanner, ScanResult} from '../scanner';
-import {Target, RuleType} from '../rules';
+import {Target, RuleType, ResourceGraphRule} from '../rules';
 import {format, LogOptions} from '../commandHelper';
 import cli from 'cli-ux';
 import chalk = require('chalk');
@@ -33,7 +33,7 @@ export default class Scan extends Command {
       description: 'Azure subscription id to scan',
       multiple: true,
     }),
-    groups: flags.string({
+    group: flags.string({
       char: 'g',
       description: 'Azure resource groups to scan',
       multiple: true,
@@ -112,12 +112,27 @@ export default class Scan extends Command {
     if (flags.verbose) this.isVerbose = true;
     if (flags.debug) this.isDebugMode = true;
     if (flags.scope) {
+      if (flags.scope.length > 1 && flags.group) {
+        this.error(
+          'Only one subscription can be scanned when using Flag --group'
+        );
+      }
       target = {
         type: RuleType.ResourceGraph,
         subscriptionIds: flags.scope,
-        groupNames: flags.groups,
+        groupNames: flags.group,
         credential: new DefaultAzureCredential(),
       };
+      if (flags.group) {
+        const nonExistingGroups = await ResourceGraphRule.getNonExisitingResourceGroups(
+          target
+        );
+        for (const g of nonExistingGroups) {
+          this.warn(
+            `Resource Group '${g}' does not exist in this subscription`
+          );
+        }
+      }
     } else if (flags.dummy) {
       target = {type: RuleType.Dummy, context: {}};
     } else {

--- a/test/azure/commands/scan.spec.ts
+++ b/test/azure/commands/scan.spec.ts
@@ -1,11 +1,13 @@
 import {test, expect} from '@oclif/test';
-import {subscriptionId} from '..';
+import {resourceGroup, resourceGroup2, subscriptionId} from '..';
 import {RuleType} from '../../../src/rules';
 import {Scanner} from '../../../src/scanner';
 
 describe('Scan Integration Tests', function () {
   this.slow(3000);
   this.timeout(5000);
+  const group1VNetId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Network/virtualNetworks/vnet`;
+  const group2VNetId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup2}/providers/Microsoft.Network/virtualNetworks/vnet`;
   test
     .stdout()
     .command(['scan', '--scope', subscriptionId, '-f', '../test/rules.json'])
@@ -18,6 +20,48 @@ describe('Scan Integration Tests', function () {
           r => r.type === RuleType.ResourceGraph
         ).length;
         expect(stdout).to.contain(`${totalResourceGraphRules} scanned`);
+      }
+    );
+  test
+    .stdout()
+    .command([
+      'scan',
+      '-s',
+      subscriptionId,
+      '-g',
+      resourceGroup,
+      '-f',
+      '../test/rules.json',
+    ])
+    .it(
+      'runs scan -s [subscriptionId] -g [resourceGroup] -f ../test/rules.json',
+      async ({stdout}) => {
+        const scanner = new Scanner();
+        await scanner.loadRulesFromFile('../test/rules.json');
+        expect(stdout).to.contain(group1VNetId);
+        expect(stdout).to.not.contain(group2VNetId);
+      }
+    );
+  test
+    .stdout()
+    .command([
+      'scan',
+      '-s',
+      subscriptionId,
+      '-g',
+      resourceGroup,
+      '-g',
+      resourceGroup2,
+      '-f',
+      '../test/rules.json',
+    ])
+    .it(
+      'runs scan -s [subscriptionId] -g [resourceGroup1] -g [resourceGroup2] -f ../test/rules.json',
+      async ({stdout}) => {
+        const scanner = new Scanner();
+        await scanner.loadRulesFromFile('../test/rules.json');
+        expect(stdout).to.contain(group1VNetId);
+        expect(stdout).to.contain(group2VNetId);
       }
     );
 });

--- a/test/azure/index.ts
+++ b/test/azure/index.ts
@@ -28,3 +28,7 @@ export const resourceGroup = env
   .get(environment.resourceGroup)
   .default(defaultResourceGroup)
   .asString();
+export const resourceGroup2 = env
+  .get(environment.resourceGroup2)
+  .default(defaultResourceGroup + '-2')
+  .asString();

--- a/test/azure/provision.ts
+++ b/test/azure/provision.ts
@@ -1,6 +1,12 @@
 import {ResourceManagementClient} from '@azure/arm-resources';
 import {AzureIdentityCredentialAdapter} from '../../src/azure';
-import {credential, resourceGroup, subscriptionId, testRegion} from '.';
+import {
+  credential,
+  resourceGroup,
+  resourceGroup2,
+  subscriptionId,
+  testRegion,
+} from '.';
 
 export async function provisionEnvironment() {
   const resourceClient = new ResourceManagementClient(
@@ -11,6 +17,9 @@ export async function provisionEnvironment() {
   await resourceClient.resourceGroups.createOrUpdate(resourceGroup, {
     location: testRegion,
   });
+  await resourceClient.resourceGroups.createOrUpdate(resourceGroup2, {
+    location: testRegion,
+  });
   await resourceClient.deployments.createOrUpdate(
     resourceGroup,
     resourceGroup,
@@ -18,6 +27,14 @@ export async function provisionEnvironment() {
       properties: {
         mode: 'Incremental',
         template: require('./templates/azuredeploy.json'),
+        parameters: {
+          resourceGroup2: {
+            value: resourceGroup2,
+          },
+          location: {
+            value: testRegion,
+          },
+        },
       },
     }
   );
@@ -29,6 +46,7 @@ export async function teardownEnvironment() {
     subscriptionId
   );
   await resourceClient.resourceGroups.beginDeleteMethod(resourceGroup);
+  await resourceClient.resourceGroups.beginDeleteMethod(resourceGroup2);
 }
 
 async function main() {

--- a/test/azure/rules.spec.ts
+++ b/test/azure/rules.spec.ts
@@ -20,7 +20,7 @@ describe('Resource Graph Rule', function () {
     });
     const target: ResourceGraphTarget = {
       type: RuleType.ResourceGraph,
-      subscriptionId,
+      subscriptionIds: [subscriptionId],
       credential: new DefaultAzureCredential(),
     };
     const result = await rule.execute(target);

--- a/test/azure/scanner.spec.ts
+++ b/test/azure/scanner.spec.ts
@@ -10,7 +10,7 @@ describe('Scanner', function () {
   it('can execute resource graph rules', async () => {
     const target: ResourceGraphTarget = {
       type: RuleType.ResourceGraph,
-      subscriptionId,
+      subscriptionIds: [subscriptionId],
       credential: new DefaultAzureCredential(),
     };
     const scanner = new Scanner();

--- a/test/azure/templates/azuredeploy.json
+++ b/test/azure/templates/azuredeploy.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroup2": {
+      "defaultValue": "aza-resource-group-2",
+      "type": "string"
+    },
+    "location": {
+      "defaultValue": "westus",
+      "type": "string"
+    }
+  },
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
@@ -11,6 +21,34 @@
         "addressSpace": {
           "addressPrefixes": [
             "10.0.0.0/8"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[parameters('resourceGroup2')]",
+      "resourceGroup": "[parameters('resourceGroup2')]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "type": "Microsoft.Network/virtualNetworks",
+              "apiVersion": "2020-05-01",
+              "name": "vnet",
+              "location": "[parameters('location')]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "10.0.0.0/8"
+                  ]
+                }
+              }
+            }
           ]
         }
       }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,6 +1,7 @@
 // Environment variables that are used by the test suite
 export const environment = {
   resourceGroup: 'AZA_TEST_RESOURCE_GROUP',
+  resourceGroup2: 'AZA_TEST_RESOURCE_GROUP_2',
   subscriptionId: 'AZA_TEST_SUBSCRIPTION_ID',
   runIntegrationTests: 'AZA_TEST_INTEGRATION',
 };

--- a/test/unit/commands/scan.spec.ts
+++ b/test/unit/commands/scan.spec.ts
@@ -14,4 +14,12 @@ describe('Scan Unit Tests', function () {
     .command(['scan', '--scope'])
     .exit(2)
     .it('exits with error code 2 when running scan --scope without a value');
+  test
+    .stdout()
+    .stderr()
+    .command(['scan', '-s', 'subId1', '-s', 'subId2', '-g', 'resourceGroup'])
+    .exit(2)
+    .it(
+      'exits with error code 2 when running providing multiple subscriptions and 1 or more resource groups'
+    );
 });

--- a/test/unit/rules.spec.ts
+++ b/test/unit/rules.spec.ts
@@ -46,7 +46,7 @@ describe('Resource Graph Rule', () => {
       'Id column was not returned from Azure Resource Graph'
     );
   });
-  it("can modify a query that does not start with 'Resources |' to include resource groups", () => {
+  it('can modify a query to target resource groups', () => {
     const rule = new ResourceGraphRule({
       name: 'test-rule',
       query: "Resources | where type =~ 'Microsoft.Network/virtualNetworks'",
@@ -59,17 +59,16 @@ describe('Resource Graph Rule', () => {
       "Resources | where resourceGroup in~ ('group1', 'group2', 'group3') | where type =~ 'Microsoft.Network/virtualNetworks'";
     expect(modifiedQuery).to.equal(expectedQuery);
   });
-  it("can modify a query that does not start with 'Resources |' to include resource groups", () => {
+  it('should throw an error when modfiying an invalid query', () => {
     const rule = new ResourceGraphRule({
       name: 'test-rule',
       query: "where type =~ 'Microsoft.Network/virtualNetworks'",
-      description: 'Intentional bad query',
+      description: 'Does not include the inital table name',
       type: RuleType.ResourceGraph,
     });
-    const groupNames = ['group1', 'group2', 'group3'];
-    const modifiedQuery = rule.getQueryByGroups(groupNames);
-    const expectedQuery =
-      "Resources | where resourceGroup in~ ('group1', 'group2', 'group3') | where type =~ 'Microsoft.Network/virtualNetworks'";
-    expect(modifiedQuery).to.equal(expectedQuery);
+    const groupNames = ['group1', 'group2'];
+    expect(() => rule.getQueryByGroups(groupNames)).to.throw(
+      "Invalid Query. All queries must start with '<tableName> |'"
+    );
   });
 });

--- a/test/unit/rules.spec.ts
+++ b/test/unit/rules.spec.ts
@@ -46,4 +46,30 @@ describe('Resource Graph Rule', () => {
       'Id column was not returned from Azure Resource Graph'
     );
   });
+  it("can modify a query that does not start with 'Resources |' to include resource groups", () => {
+    const rule = new ResourceGraphRule({
+      name: 'test-rule',
+      query: "Resources | where type =~ 'Microsoft.Network/virtualNetworks'",
+      description: 'Intentional bad query',
+      type: RuleType.ResourceGraph,
+    });
+    const groupNames = ['group1', 'group2', 'group3'];
+    const modifiedQuery = rule.getQueryByGroups(groupNames);
+    const expectedQuery =
+      "Resources | where resourceGroup in~ ('group1', 'group2', 'group3') | where type =~ 'Microsoft.Network/virtualNetworks'";
+    expect(modifiedQuery).to.equal(expectedQuery);
+  });
+  it("can modify a query that does not start with 'Resources |' to include resource groups", () => {
+    const rule = new ResourceGraphRule({
+      name: 'test-rule',
+      query: "where type =~ 'Microsoft.Network/virtualNetworks'",
+      description: 'Intentional bad query',
+      type: RuleType.ResourceGraph,
+    });
+    const groupNames = ['group1', 'group2', 'group3'];
+    const modifiedQuery = rule.getQueryByGroups(groupNames);
+    const expectedQuery =
+      "Resources | where resourceGroup in~ ('group1', 'group2', 'group3') | where type =~ 'Microsoft.Network/virtualNetworks'";
+    expect(modifiedQuery).to.equal(expectedQuery);
+  });
 });


### PR DESCRIPTION
closes #47 
closes #60

- adds feature to scan multiple subscriptions
- adds feature to scan 1 or more resource groups in a single subscription
- notifies user if resource group is not found in subscription
- some work might still to be done on the getQueryByGroups method
    - currently it looks for the first '|' and has a requirement to author rules with '\<tableName\> |'
    -  however because it only looks for the first pipe and not the table name, it is possible to have a valid resource graph query that fails when modifying a query to include resource groups, so this may need to be addressed down the road
    - I will create issue to reflect that 
- adds to GitHub actions a trigger for creating executables   
    - this is because of a bug found with https://github.com/vercel/pkg-fetch
    - just add the comment ' ' to the PR description to the run that job  

cli examples:
aza scan -s [...subscriptions]
aza scan -s [subscription1] -s [subscription2]
 
aza scan -s [subscription] -g [...resourceGroupNames]  
aza scan -s [subscription] -g [resourceGroupName1] -g [resourceGroupName2]   

aza scan -s [subscription] -s [subscription2] -g [resourceGroupName1] -g [resourceGroupName2]   => throws error