### PR TITLE
Post processing clean up

### DIFF
--- a/docs/rules-armTemplate.md
+++ b/docs/rules-armTemplate.md
@@ -77,3 +77,27 @@ Since exported templated do not return the config app settings for function apps
     }
   }
 ```
+
+*Note*
+When writing queries for ARM templates, it is important to know when to use `backticks` and when to use `single quotes`. If you are searching for an integer, then you should use `backticks`. If you are searching a string, often times you use either `single quotes` or `backticks`. However, if the property is a stringed integer `"1"` then backticks will not accurately evaluate the property. If it is not clear that the property you are searching for will come back as a string or an integer, it is suggested construct a query that checks for both options to prevent rules from being inaccurately evaluated. See the examples below for the JMESPATH behavior.
+
+``` json 
+{
+  "stringInteger": "1",
+  "string": "Hello World",
+  "integer": 1,
+}
+```
+
+Using the above JSON object:
+```
+stringInteger == '1' => true  
+stringInteger == `1` => false
+
+string == 'Hello World' => true  
+string == `Hello World` => true
+
+integer == '1' => false  
+integer == `1` => true
+
+```

--- a/test/azure/commands/scan.spec.ts
+++ b/test/azure/commands/scan.spec.ts
@@ -17,7 +17,7 @@ describe('Scan Integration Tests', function () {
       this.skip();
     }
   });
-  const nonExistingGroup = `i-should-exist-${Date.now()}-1`;
+  const nonExistingGroup = `i-should-not-exist-${Date.now()}-1`;
   const group1VNetId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Network/virtualNetworks/vnet`;
   const group2VNetId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup2}/providers/Microsoft.Network/virtualNetworks/azatestvnet2`;
   test

--- a/test/unit/rules/armTemplate.spec.ts
+++ b/test/unit/rules/armTemplate.spec.ts
@@ -1,7 +1,13 @@
 import {expect} from 'chai';
 import {resourceGroup, subscriptionId} from '../../azure';
 import {ScanResult} from '../../../src/scanner';
-import {ARMTarget, ARMTemplateRule, RuleType} from '../../../src/rules';
+import {
+  ARMResource,
+  ARMTarget,
+  ARMTemplateRule,
+  filterAsync,
+  RuleType,
+} from '../../../src/rules';
 import {ResourceManagementClient} from '@azure/arm-resources';
 import {TokenCredential} from '@azure/identity';
 
@@ -164,5 +170,11 @@ describe('ARM Template Rule', () => {
     );
     const expectedResult = `https://management.azure.com/subscriptions/${testARMTarget.subscriptionId}/resourceGroups/${testARMTarget.groupName}/providers/${template.resources[0].type}/${template.resources[0].name}/${evaluation.request.operation}?api-version=${template.resources[0].apiVersion}`;
     expect(result).to.equal(expectedResult);
+  });
+
+  it('validates the filterAsync and mapAsync Methods work with an empty array', async () => {
+    const array = new Array<ARMResource>();
+    const results = await filterAsync(array, () => Promise.resolve(false));
+    expect(results).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
closes #83 
* adds tests for asyncFilter method => works as expected with an empty array
* Fixes user defined type guard for isRequestEvaluation
* adds guidance for useing backticks vs single quotes in JMESPATH queries
* fixes semantic error in constant value in test/azure/commands/scan.spec.ts 