### PR TITLE
Rg request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azca",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rules.json
+++ b/rules.json
@@ -10,7 +10,7 @@
   },
   {
     "name": "event-hubs-not-locked-down-1",
-    "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
+    "description": "Finds Event Hubs with a network rule set having zero IP and virtual network rules and the defaultAction is Deny.",
     "type": "ResourceGraph",
     "evaluation": {
       "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
@@ -20,11 +20,11 @@
         "query": "properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`"
       }
     },
-    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
+    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-1"
   },
   {
     "name": "event-hubs-not-locked-down-2",
-    "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
+    "description": "Finds Event Hubs with a network rule set having one or more IP and virtual network rules for the namespace but the defaultAction is not set to 'Deny'",
     "type": "ResourceGraph",
     "evaluation": {
       "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
@@ -34,7 +34,7 @@
         "query": "properties.defaultAction == `Allow` && (length(properties.ipRules) > `0` || length(properties.virtualNetworkRules) > `0`)"
       }
     },
-    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
+    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-2"
   },
   {
     "name": "accidental-public-storage",

--- a/rules.json
+++ b/rules.json
@@ -14,11 +14,11 @@
     "type": "ResourceGraph",
     "evaluation": {
       "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
-      "request": {
+      "request": [{
         "operation": "networkRuleSets/default",
         "httpMethod": "GET",
         "query": "properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`"
-      }
+      }]
     },
     "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-1"
   },
@@ -28,13 +28,34 @@
     "type": "ResourceGraph",
     "evaluation": {
       "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
-      "request": {
+      "request": [{
         "operation": "networkRuleSets/default",
         "httpMethod": "GET",
         "query": "properties.defaultAction == `Allow` && (length(properties.ipRules) > `0` || length(properties.virtualNetworkRules) > `0`)"
-      }
+      }]
     },
     "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-2"
+  },
+  {
+    "name": "function-app-vnet-integration-misconfiguration",
+    "description": "Finds Function Apps integrated with a VNET but the app settings are not properly configured",
+    "type": "ResourceGraph",
+    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#function-app-vnet-integration-misconfiguration",
+    "evaluation": {
+      "query": "Resources | where type =~ 'Microsoft.Web/sites' and kind =~ 'functionapp'",
+      "request": [
+        {
+          "operation": "virtualNetworkConnections",
+          "httpMethod": "GET",
+          "query": "exists"
+        },
+        {
+        "operation": "config/appsettings/list",
+        "httpMethod": "POST",
+        "query": "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'"
+      }
+    ]
+    }
   },
   {
     "name": "accidental-public-storage",
@@ -75,11 +96,11 @@
     "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#function-app-vnet-integration-misconfiguration",
     "evaluation": {
       "query": "type == 'Microsoft.Web/sites' && kind == 'functionapp'",
-      "request": {
+      "request": [{
         "operation": "config/appsettings/list",
         "httpMethod": "POST",
         "query": "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'"
-      },
+      }],
       "and": [
         {
           "query": "type == 'Microsoft.Web/sites/virtualNetworkConnections' && starts_with(name, '{{parent.name}}/')"

--- a/rules.json
+++ b/rules.json
@@ -16,6 +16,7 @@
       "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
       "request": {
         "operation": "networkRuleSets/default",
+        "httpMethod": "GET",
         "query": "properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`"
       }
     },
@@ -62,6 +63,7 @@
       "query": "type == 'Microsoft.Web/sites' && kind == 'functionapp'",
       "request": {
         "operation": "config/appsettings/list",
+        "httpMethod": "POST",
         "query": "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'"
       },
       "and": [

--- a/rules.json
+++ b/rules.json
@@ -3,9 +3,24 @@
     "name": "accidental-public-storage",
     "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
     "type": "ResourceGraph",
-    "query": "Resources | where type=~ 'Microsoft.Storage/storageAccounts' and isnotempty(properties.privateEndpointConnections[0]) and properties.networkAcls.defaultAction=~ 'Allow'",
+    "evaluation": {
+      "query": "Resources | where type=~ 'Microsoft.Storage/storageAccounts' and isnotempty(properties.privateEndpointConnections[0]) and properties.networkAcls.defaultAction=~ 'Allow'"
+    },
     "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
   },
+    {
+      "name": "event-hub-test",
+      "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
+      "type": "ResourceGraph",
+      "evaluation": {
+        "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
+        "request": {
+          "operation": "networkRuleSets/default",
+          "query": "properties.defaultAction == `Deny`"
+        }
+      },
+      "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
+    },
   {
     "name": "accidental-public-storage",
     "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",

--- a/rules.json
+++ b/rules.json
@@ -8,19 +8,19 @@
     },
     "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
   },
-    {
-      "name": "event-hub-test",
-      "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
-      "type": "ResourceGraph",
-      "evaluation": {
-        "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
-        "request": {
-          "operation": "networkRuleSets/default",
-          "query": "properties.defaultAction == `Deny`"
-        }
-      },
-      "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
+  {
+    "name": "event-hub-test",
+    "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
+    "type": "ResourceGraph",
+    "evaluation": {
+      "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
+      "request": {
+        "operation": "networkRuleSets/default",
+        "query": "properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`"
+      }
     },
+    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
+  },
   {
     "name": "accidental-public-storage",
     "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",

--- a/rules.json
+++ b/rules.json
@@ -9,7 +9,7 @@
     "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
   },
   {
-    "name": "event-hub-test",
+    "name": "event-hubs-not-locked-down-1",
     "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
     "type": "ResourceGraph",
     "evaluation": {
@@ -18,6 +18,20 @@
         "operation": "networkRuleSets/default",
         "httpMethod": "GET",
         "query": "properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`"
+      }
+    },
+    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
+  },
+  {
+    "name": "event-hubs-not-locked-down-2",
+    "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
+    "type": "ResourceGraph",
+    "evaluation": {
+      "query": "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
+      "request": {
+        "operation": "networkRuleSets/default",
+        "httpMethod": "GET",
+        "query": "properties.defaultAction == `Allow` && (length(properties.ipRules) > `0` || length(properties.virtualNetworkRules) > `0`)"
       }
     },
     "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"

--- a/src/commands/scan/index.ts
+++ b/src/commands/scan/index.ts
@@ -98,9 +98,8 @@ $ azca scan:arm --subscription <subscriptionId> --group <resourceGroupName>
 
   async scan(target: Target, rulesFile: string | undefined) {
     const scanner = new Scanner();
-    await scanner.loadRulesFromFile(rulesFile);
     cli.action.start('Scanning');
-    const results = await scanner.scan(target);
+    const results = await scanner.scan(target, rulesFile);
     cli.action.stop();
     this.print(results);
   }

--- a/src/commands/scan/rg.ts
+++ b/src/commands/scan/rg.ts
@@ -3,6 +3,8 @@ import Scan from './index';
 import {RuleType, ResourceGraphRule, ResourceGraphTarget} from '../../rules';
 import {DefaultAzureCredential} from '@azure/identity';
 import {cli} from 'cli-ux';
+import {AzureIdentityCredentialAdapter} from '../../azure';
+import {ResourceManagementClient} from '@azure/arm-resources';
 
 export default class ScanResourceGraph extends Scan {
   static description =

--- a/src/commands/scan/rg.ts
+++ b/src/commands/scan/rg.ts
@@ -3,8 +3,6 @@ import Scan from './index';
 import {RuleType, ResourceGraphRule, ResourceGraphTarget} from '../../rules';
 import {DefaultAzureCredential} from '@azure/identity';
 import {cli} from 'cli-ux';
-import {AzureIdentityCredentialAdapter} from '../../azure';
-import {ResourceManagementClient} from '@azure/arm-resources';
 
 export default class ScanResourceGraph extends Scan {
   static description =

--- a/src/rules/armTemplate.ts
+++ b/src/rules/armTemplate.ts
@@ -166,11 +166,9 @@ export class ARMTemplateRule implements BaseRule<ARMTarget> {
       ruleName: this.name,
       description: this.description,
       total: resourceIds.length,
+      recommendation: this.recommendation,
       resourceIds: resourceIds,
     };
-    if (this.recommendation) {
-      scanResult.recommendation = this.recommendation;
-    }
     return scanResult;
   }
 

--- a/src/rules/armTemplate.ts
+++ b/src/rules/armTemplate.ts
@@ -3,15 +3,23 @@ import {TokenCredential} from '@azure/identity';
 import JMESPath = require('jmespath');
 import Handlebars = require('handlebars');
 
-import {BaseRule, RuleType} from '.';
+import {
+  BaseRule,
+  RuleType,
+  Evaluation,
+  RequestEvaluation,
+  isRequestEvaluation,
+  isAndEvaluation,
+  HttpMethods,
+} from '.';
 import {AzureIdentityCredentialAdapter} from '../azure';
 import {ScanResult} from '../scanner';
 
-// needed for sendRequest method
-// from @azure/core-http => https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-core-http/1.2.4/globals.html#httpmethods
-enum HttpMethods {
-  POST = 'POST',
-}
+// // needed for sendRequest method
+// // from @azure/core-http => https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-core-http/1.2.4/globals.html#httpmethods
+// enum HttpMethods {
+//   POST = 'POST',
+// }
 
 export interface ARMTemplate {
   $schema: string;
@@ -37,31 +45,31 @@ export interface ARMTarget {
 }
 
 // All evaluations contain a JMESPath query that operate on ARM resources
-type BaseEvaluation = {
-  query: string;
-};
+// type BaseEvaluation = {
+//   query: string;
+// };
 
 // Some evaluations may check for additional conditions
-type AndEvaluation = BaseEvaluation & {
-  and: Array<Evaluation>;
-};
+// type AndEvaluation = BaseEvaluation & {
+//   and: Array<Evaluation>;
+// };
 
-type RequestEvaluation = BaseEvaluation & {
-  request: {
-    operation: string;
-    query: string;
-  };
-};
+// type RequestEvaluation = BaseEvaluation & {
+//   request: {
+//     operation: string;
+//     query: string;
+//   };
+// };
 
-function isAndEvaluation(evaluation: Evaluation): evaluation is AndEvaluation {
-  return (evaluation as AndEvaluation).and !== undefined;
-}
+// function isAndEvaluation(evaluation: Evaluation): evaluation is AndEvaluation {
+//   return (evaluation as AndEvaluation).and !== undefined;
+// }
 
-function isRequestEvaluation(
-  evaluation: Evaluation
-): evaluation is RequestEvaluation {
-  return (evaluation as RequestEvaluation).request !== undefined;
-}
+// function isRequestEvaluation(
+//   evaluation: Evaluation
+// ): evaluation is RequestEvaluation {
+//   return (evaluation as RequestEvaluation).request !== undefined;
+// }
 
 // returns a resolved promise so that any async calls in the callback are completed before returning
 function mapAsync<T1, T2>(
@@ -83,21 +91,21 @@ export async function filterAsync<T>(
 }
 
 // Evaluations may be standalone or composite
-type Evaluation = BaseEvaluation | AndEvaluation | RequestEvaluation;
+// export type Evaluation = BaseEvaluation | AndEvaluation | RequestEvaluation;
 
 export class ARMTemplateRule implements BaseRule<ARMTarget> {
   type: RuleType.ARM;
   name: string;
   description: string;
   evaluation: Evaluation;
-  recommendation?: string;
+  recommendation: string;
 
   constructor(rule: {
     type: RuleType.ARM;
     name: string;
     description: string;
     evaluation: Evaluation;
-    recommendation?: string;
+    recommendation: string;
   }) {
     this.type = rule.type;
     this.name = rule.name;

--- a/src/rules/armTemplate.ts
+++ b/src/rules/armTemplate.ts
@@ -11,15 +11,10 @@ import {
   isRequestEvaluation,
   isAndEvaluation,
   HttpMethods,
+  filterAsync,
 } from '.';
 import {AzureIdentityCredentialAdapter} from '../azure';
 import {ScanResult} from '../scanner';
-
-// // needed for sendRequest method
-// // from @azure/core-http => https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-core-http/1.2.4/globals.html#httpmethods
-// enum HttpMethods {
-//   POST = 'POST',
-// }
 
 export interface ARMTemplate {
   $schema: string;
@@ -43,55 +38,6 @@ export interface ARMTarget {
   credential: TokenCredential;
   client: ResourceManagementClient;
 }
-
-// All evaluations contain a JMESPath query that operate on ARM resources
-// type BaseEvaluation = {
-//   query: string;
-// };
-
-// Some evaluations may check for additional conditions
-// type AndEvaluation = BaseEvaluation & {
-//   and: Array<Evaluation>;
-// };
-
-// type RequestEvaluation = BaseEvaluation & {
-//   request: {
-//     operation: string;
-//     query: string;
-//   };
-// };
-
-// function isAndEvaluation(evaluation: Evaluation): evaluation is AndEvaluation {
-//   return (evaluation as AndEvaluation).and !== undefined;
-// }
-
-// function isRequestEvaluation(
-//   evaluation: Evaluation
-// ): evaluation is RequestEvaluation {
-//   return (evaluation as RequestEvaluation).request !== undefined;
-// }
-
-// returns a resolved promise so that any async calls in the callback are completed before returning
-function mapAsync<T1, T2>(
-  array: T1[],
-  callback: (value: T1, index: number, array: T1[]) => Promise<T2>
-): Promise<T2[]> {
-  return Promise.all(array.map(callback));
-}
-
-// if the array is empty, it returns an empty array
-export async function filterAsync<T>(
-  array: T[],
-  callback: (value: T, index: number, array: T[]) => Promise<boolean>
-): Promise<T[]> {
-  // creates boolean array and maintains the same index order as the original array
-  const mappedArray = await mapAsync(array, callback);
-  // filters over the original array based on the mappedArray boolean at each index
-  return array.filter((_, index) => mappedArray[index]);
-}
-
-// Evaluations may be standalone or composite
-// export type Evaluation = BaseEvaluation | AndEvaluation | RequestEvaluation;
 
 export class ARMTemplateRule implements BaseRule<ARMTarget> {
   type: RuleType.ARM;

--- a/src/rules/armTemplate.ts
+++ b/src/rules/armTemplate.ts
@@ -157,12 +157,15 @@ export class ARMTemplateRule implements BaseRule<ARMTarget> {
     resource: ARMResource,
     evaluation: RequestEvaluation
   ) {
+    if (!isRequestEvaluation(this.evaluation)) {
+      throw Error('A valid request evalutation was not found');
+    }
     const token = await target.credential.getToken(
       'https://graph.microsoft.com/.default'
     );
     const options = {
       url: this.getRequestUrl(target, resource, evaluation),
-      method: HttpMethods.POST,
+      method: this.evaluation.request.httpMethod as HttpMethods,
       headers: {
         Authorization: `Bearer ${token?.token}`,
         'Content-Type': 'application/json',

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -10,7 +10,6 @@ import {
   isRequestEvaluation,
   HttpMethods,
   filterAsync,
-  RequestEvaluation,
 } from '.';
 import {AzureClient, AzureIdentityCredentialAdapter} from '../azure';
 import {ScanResult} from '../scanner';
@@ -116,7 +115,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
 
   async sendRequest(target: ResourceGraphTarget, resourceId: string) {
     if (!isRequestEvaluation(this.evaluation)) {
-      throw Error('A valid request evalutation was not found');
+      throw Error('A valid request evaluation was not found');
     }
     const token = await target.credential.getToken(
       'https://graph.microsoft.com/.default'

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -132,7 +132,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
       },
     };
     let response = await resourceManagementClient.sendRequest(options);
-    // if the response returns an error because of an invalid api verison, then parse the error message to retrieve a valid one and try again
+    // if the response returns an error because the default api verison is invalid, then parse the error message to retrieve a valid one and try again
     if (
       response.status === 400 &&
       response.parsedBody.error.code === 'NoRegisteredProviderFound'
@@ -176,18 +176,18 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
     throw Error('Unable to find a valid api version');
   }
 
-  async getLatestApiVersion(
+  async getDefaultApiVersion(
     resourceId: string,
     client: ResourceManagementClient
   ) {
     const provider = this.getElementFromId('provider', resourceId);
     const resourceType = this.getElementFromId('resourceType', resourceId);
     const providerResponse = await client.providers.get(provider);
-    const apiVersions = providerResponse.resourceTypes?.find(
+    const apiVersion = providerResponse.resourceTypes?.find(
       r => r.resourceType === resourceType
-    )?.apiVersions;
-    if (apiVersions) {
-      return apiVersions[0];
+    )?.defaultApiVersion;
+    if (apiVersion) {
+      return apiVersion;
     }
     throw Error('unable to retrieve a valid api version');
   }
@@ -221,7 +221,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
     apiVersion?: string
   ) {
     if (!apiVersion) {
-      apiVersion = await this.getLatestApiVersion(resourceId, client);
+      apiVersion = await this.getDefaultApiVersion(resourceId, client);
     }
     if (isRequestEvaluation(this.evaluation)) {
       return `https://management.azure.com/${resourceId}/${this.evaluation.request.operation}?api-version=${apiVersion}`;

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -64,7 +64,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
     }
 
     let resourceIds = this.convertResourcesResponseToIds(response);
-    // after first evaluation runs, evaluate the request evalution if it exsists
+    // after first evaluation runs, evaluate the request evalution if it exists
     resourceIds = await filterAsync(resourceIds, async resourceId => {
       if (isRequestEvaluation(this.evaluation)) {
         const response = await this.sendRequest(target, resourceId);

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -114,6 +114,9 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
   }
 
   async sendRequest(target: ResourceGraphTarget, resourceId: string) {
+    if (!isRequestEvaluation(this.evaluation)) {
+      throw Error('A valid request evalutation was not found');
+    }
     const token = await target.credential.getToken(
       'https://graph.microsoft.com/.default'
     );
@@ -122,7 +125,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
     );
     const options = {
       url: await this.getRequestUrl(resourceId, resourceManagementClient),
-      method: HttpMethods.GET,
+      method: this.evaluation.request.httpMethod as HttpMethods,
       headers: {
         Authorization: `Bearer ${token?.token}`,
         'Content-Type': 'application/json',

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -1,8 +1,17 @@
 import {ResourceGraphModels} from '@azure/arm-resourcegraph';
-import {TokenCredential} from '@azure/identity';
-import {BaseRule, RuleType} from '.';
-import {AzureClient} from '../azure';
+import {ResourceManagementClient} from '@azure/arm-resources';
+import {DefaultAzureCredential, TokenCredential} from '@azure/identity';
+import {
+  BaseRule,
+  RuleType,
+  Evaluation,
+  isRequestEvaluation,
+  HttpMethods,
+} from '.';
+import {AzureClient, AzureIdentityCredentialAdapter} from '../azure';
 import {ScanResult} from '../scanner';
+import {filterAsync} from './armTemplate';
+import JMESPath = require('jmespath');
 
 export interface ResourceGraphTarget {
   type: RuleType.ResourceGraph;
@@ -20,20 +29,20 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
   type: RuleType.ResourceGraph;
   name: string;
   description: string;
-  query: string;
-  recommendation?: string;
+  evaluation: Evaluation;
+  recommendation: string;
 
   constructor(rule: {
     type: RuleType.ResourceGraph;
     name: string;
     description: string;
-    query: string;
-    recommendation?: string;
+    evaluation: Evaluation;
+    recommendation: string;
   }) {
     this.type = rule.type;
     this.name = rule.name;
     this.description = rule.description;
-    this.query = rule.query;
+    this.evaluation = rule.evaluation;
     this.recommendation = rule.recommendation;
   }
 
@@ -48,11 +57,26 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
       );
     } else {
       response = await client.queryResources(
-        this.query,
+        this.evaluation.query,
         target.subscriptionIds
       );
     }
-    return this.toScanResult(response);
+
+    let resourceIds = this.convertResourcesResponseToIds(response);
+
+    resourceIds = await filterAsync(resourceIds, async resourceId => {
+      if (isRequestEvaluation(this.evaluation)) {
+        const response = await this.sendRequest(target, resourceId);
+        console.log(response);
+        return JMESPath.search(
+          response.parsedBody,
+          this.evaluation.request.query
+        );
+      } else {
+        return true;
+      }
+    });
+    return this.toScanResult(resourceIds);
   }
 
   static async getNonExistingResourceGroups(target: ResourceGraphTarget) {
@@ -77,19 +101,146 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
   getQueryByGroups(groupNames: string[]) {
     const formattedGroups = groupNames.map(name => `'${name}'`).join(', ');
     const groupQuery = `| where resourceGroup in~ (${formattedGroups})`;
-    const firstPipeIndex = this.query.indexOf('|');
+    const firstPipeIndex = this.evaluation.query.indexOf('|');
     if (firstPipeIndex === -1) {
       // while it is a Microsoft recommendation to start Resource Graph queries with the table name,
       // for this application it is a requirement in order to support filtering for resource groups in the query
       throw Error("Invalid Query. All queries must start with '<tableName> |'");
     } else {
-      const initalTable = this.query.slice(0, firstPipeIndex - 1);
-      const queryEnding = this.query.slice(firstPipeIndex);
+      const initalTable = this.evaluation.query.slice(0, firstPipeIndex - 1);
+      const queryEnding = this.evaluation.query.slice(firstPipeIndex);
       return `${initalTable} ${groupQuery} ${queryEnding}`;
     }
   }
 
-  toScanResult(response: ResourceGraphModels.ResourcesResponse): ScanResult {
+  async sendRequest(
+    target: ResourceGraphTarget,
+    resourceId: string,
+    apiVersion?: string
+  ) {
+    const token = await target.credential.getToken(
+      'https://graph.microsoft.com/.default'
+    );
+    const resourceManagementClient = await this.getResourceManagmentClient(
+      resourceId
+    );
+
+    const options = {
+      url: await this.getRequestUrl(
+        resourceId,
+        resourceManagementClient,
+        apiVersion
+      ),
+      method: HttpMethods.GET,
+      headers: {
+        Authorization: `Bearer ${token?.token}`,
+        'Content-Type': 'application/json',
+      },
+    };
+    const response = await resourceManagementClient.sendRequest(options);
+    if (
+      response.status === 400 &&
+      response.parsedBody.error.code === 'NoRegisteredProviderFound'
+    ) {
+      if (apiVersion) {
+        throw Error('Something went wrong');
+      }
+      apiVersion = this.getApiVersionFromError(
+        response.parsedBody.error.message
+      );
+      return await this.sendRequest(target, resourceId, apiVersion);
+    }
+    return response;
+  }
+
+  async getResourceManagmentClient(resourceId: string) {
+    const subscriptionId = this.getElementFromId('subscription', resourceId);
+    return await new ResourceManagementClient(
+      new AzureIdentityCredentialAdapter(new DefaultAzureCredential()),
+      subscriptionId
+    );
+  }
+
+  getApiVersionFromError(errorMessage: string) {
+    let apiVersion;
+    const splitMessage = errorMessage.split('The supported api-versions are ');
+    const versions = splitMessage[1];
+    const regExps = [
+      new RegExp(/\d\d\d\d-\d\d-\d\d-preview/),
+      new RegExp(/\d\d\d\d-\d\d-\d\d/),
+    ];
+
+    function match(regex: RegExp) {
+      const match = versions.match(regex);
+      if (match) {
+        return match[0];
+      } else {
+        return null;
+      }
+    }
+
+    for (const r of regExps) {
+      apiVersion = match(r);
+      if (apiVersion) {
+        return apiVersion;
+      }
+    }
+    throw Error('Unable to find a valid apiVersion');
+  }
+  async getApiVersion(resourceId: string, client: ResourceManagementClient) {
+    const provider = this.getElementFromId('provider', resourceId);
+    const resourceType = this.getElementFromId('resourceType', resourceId);
+    const providers = await client.providers.get(provider);
+    const apiVersions = providers.resourceTypes?.find(
+      r => r.resourceType === resourceType
+    )?.apiVersions;
+    if (apiVersions) {
+      return apiVersions[0];
+    }
+    throw Error('unable to retrieve a valid Api Version');
+  }
+
+  getElementFromId(
+    element: 'subscription' | 'provider' | 'resourceType',
+    resourceId: string
+  ) {
+    const splitId = resourceId.split('/');
+    switch (element) {
+      case 'subscription': {
+        const subscriptionsIdx =
+          splitId.findIndex(el => el === 'subscriptions') + 1;
+        return splitId[subscriptionsIdx];
+      }
+      case 'provider': {
+        const providerNamespaceIdx =
+          splitId.findIndex(el => el === 'providers') + 1;
+        return splitId[providerNamespaceIdx];
+      }
+      case 'resourceType': {
+        const resourceTypeIdx = splitId.findIndex(el => el === 'providers') + 2;
+        return splitId[resourceTypeIdx];
+      }
+    }
+  }
+
+  async getRequestUrl(
+    resourceId: string,
+    client: ResourceManagementClient,
+    apiVersion?: string
+  ) {
+    if (!apiVersion) {
+      apiVersion = await this.getApiVersion(resourceId, client);
+    }
+    if (isRequestEvaluation(this.evaluation)) {
+      return `https://management.azure.com/${resourceId}/${this.evaluation.request.operation}?api-version=${apiVersion}`;
+    }
+    // update error message
+    throw Error('There was a problem with the request');
+  }
+
+  convertResourcesResponseToIds(
+    response: ResourceGraphModels.ResourcesResponse
+  ) {
     const cols = response.data.columns as ResourceGraphQueryResponseColumn[];
     const rows = response.data.rows as string[];
     const idIndex = cols.findIndex(c => c.name === 'id');
@@ -97,15 +248,17 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
       throw new Error('Id column was not returned from Azure Resource Graph');
     }
     const resourceIds = rows.map(r => r[idIndex]);
+    return resourceIds;
+  }
+
+  toScanResult(resourceIds: string[]): ScanResult {
     const scanResult: ScanResult = {
       ruleName: this.name,
       description: this.description,
-      total: response.totalRecords,
+      total: resourceIds.length,
+      recommendation: this.recommendation,
       resourceIds,
     };
-    if (this.recommendation) {
-      scanResult.recommendation = this.recommendation;
-    }
     return scanResult;
   }
 }

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -125,11 +125,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
       resourceId
     );
     const options = {
-      url: await this.getRequestUrl(
-        resourceId,
-        this.evaluation,
-        resourceManagementClient
-      ),
+      url: await this.getRequestUrl(resourceId, resourceManagementClient),
       method: this.evaluation.request.httpMethod as HttpMethods,
       headers: {
         Authorization: `Bearer ${token?.token}`,
@@ -147,7 +143,6 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
       );
       options.url = await this.getRequestUrl(
         resourceId,
-        this.evaluation,
         resourceManagementClient,
         apiVersion
       );
@@ -221,11 +216,13 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
 
   async getRequestUrl(
     resourceId: string,
-    evaluation: RequestEvaluation,
     client: ResourceManagementClient,
     apiVersion?: string
   ) {
-    const fullResourceId = `${resourceId}/${evaluation.request.operation}`;
+    if (!isRequestEvaluation(this.evaluation)) {
+      throw Error('There was a problem with the request evaluation');
+    }
+    const fullResourceId = `${resourceId}/${this.evaluation.request.operation}`;
     if (!apiVersion) {
       apiVersion = await this.getDefaultApiVersion(resourceId, client);
     }

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -219,7 +219,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
     }
   }
 
-  async getRequestUrl<T>(
+  async getRequestUrl(
     resourceId: string,
     evaluation: RequestEvaluation,
     client: ResourceManagementClient,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,6 +2,13 @@ import {ScanResult} from '../scanner';
 import {ARMTarget, ARMTemplateRule} from './armTemplate';
 import {ResourceGraphRule, ResourceGraphTarget} from './azureResourceGraph';
 
+// needed for sendRequest method
+// from @azure/core-http => https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-core-http/1.2.4/globals.html#httpmethods
+export enum HttpMethods {
+  POST = 'POST',
+  GET = 'GET',
+}
+
 export enum RuleType {
   ResourceGraph = 'ResourceGraph',
   ARM = 'ARM',
@@ -11,9 +18,41 @@ export interface BaseRule<T> {
   name: string;
   description: string;
   type: RuleType;
+  evaluation: Evaluation;
+  recommendation: string;
   execute?: (target: T) => Promise<ScanResult>;
 }
 
+// All evaluations contain a JMESPath query that operate on ARM resources
+type BaseEvaluation = {
+  query: string;
+};
+
+// Some evaluations may check for additional conditions
+type AndEvaluation = BaseEvaluation & {
+  and: Array<Evaluation>;
+};
+
+export type RequestEvaluation = BaseEvaluation & {
+  request: {
+    operation: string;
+    query: string;
+  };
+};
+
+export function isAndEvaluation(
+  evaluation: Evaluation
+): evaluation is AndEvaluation {
+  return (evaluation as AndEvaluation).and !== undefined;
+}
+
+export function isRequestEvaluation(
+  evaluation: Evaluation
+): evaluation is RequestEvaluation {
+  return (evaluation as RequestEvaluation).request !== undefined;
+}
+
+export type Evaluation = BaseEvaluation | AndEvaluation | RequestEvaluation;
 export type Rule = ResourceGraphRule | ARMTemplateRule;
 export type Target = ResourceGraphTarget | ARMTarget;
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -34,12 +34,18 @@ type AndEvaluation = BaseEvaluation & {
 };
 
 export type RequestEvaluation = BaseEvaluation & {
-  request: {
-    operation: string;
-    httpMethod: HttpMethods;
-    query: string;
-  };
+  request: Array<RequestEvaluationObject>;
 };
+
+export type RequestEvaluationObject = {
+  operation: string;
+  httpMethod: HttpMethods;
+  query: string | QueryOption.EXISTS;
+};
+
+export enum QueryOption {
+  EXISTS = 'exists',
+}
 
 export function isAndEvaluation(
   evaluation: Evaluation
@@ -70,6 +76,16 @@ export async function filterAsync<T>(
   const mappedArray = await mapAsync(array, callback);
   // filters over the original array based on the mappedArray boolean at each index
   return array.filter((_, index) => mappedArray[index]);
+}
+
+export async function everyAsync<T>(
+  arr: T[],
+  predicate: {(e: T): Promise<boolean>}
+) {
+  for (const e of arr) {
+    if (!(await predicate(e))) return false;
+  }
+  return true;
 }
 
 export type Evaluation = BaseEvaluation | AndEvaluation | RequestEvaluation;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -36,6 +36,7 @@ type AndEvaluation = BaseEvaluation & {
 export type RequestEvaluation = BaseEvaluation & {
   request: {
     operation: string;
+    httpMethod: HttpMethods;
     query: string;
   };
 };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -52,6 +52,25 @@ export function isRequestEvaluation(
   return (evaluation as RequestEvaluation).request !== undefined;
 }
 
+// returns a resolved promise so that any async calls in the callback are completed before returning
+function mapAsync<T1, T2>(
+  array: T1[],
+  callback: (value: T1, index: number, array: T1[]) => Promise<T2>
+): Promise<T2[]> {
+  return Promise.all(array.map(callback));
+}
+
+// if the array is empty, it returns an empty array
+export async function filterAsync<T>(
+  array: T[],
+  callback: (value: T, index: number, array: T[]) => Promise<boolean>
+): Promise<T[]> {
+  // creates boolean array and maintains the same index order as the original array
+  const mappedArray = await mapAsync(array, callback);
+  // filters over the original array based on the mappedArray boolean at each index
+  return array.filter((_, index) => mappedArray[index]);
+}
+
 export type Evaluation = BaseEvaluation | AndEvaluation | RequestEvaluation;
 export type Rule = ResourceGraphRule | ARMTemplateRule;
 export type Target = ResourceGraphTarget | ARMTarget;

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -19,18 +19,18 @@ export interface ScanResult {
 }
 
 export class Scanner {
-  rules: Rule[] = [];
-
-  async scan(target: Target) {
-    if (!this.rules.length) await this.loadRulesFromFile();
-    const filteredRules = this.rules.filter(r => r.type === target.type);
+  async scan(target: Target, filePath?: string) {
+    const rules = await this.getRulesFromFile(filePath);
+    const filteredRules = rules.filter(r => r.type === target.type);
     const results = this.execute(filteredRules, target);
     return Promise.all(results);
   }
 
-  async loadRulesFromFile(filePath = path.join(__dirname, '../rules.json')) {
+  async getRulesFromFile(
+    filePath = path.join(__dirname, '../rules.json')
+  ): Promise<Rule[]> {
     const data = await fsPromises.readFile(filePath, 'utf8');
-    this.rules = JSON.parse(data);
+    return JSON.parse(data);
   }
 
   execute(rules: Rule[], target: Target) {

--- a/test/azure/commands/scan.spec.ts
+++ b/test/azure/commands/scan.spec.ts
@@ -6,8 +6,8 @@ import {
   runIntegrationTests,
   subscriptionId,
 } from '..';
+import {getTestRules} from '../..';
 import {RuleType} from '../../../src/rules';
-import {Scanner} from '../../../src/scanner';
 
 describe('Scan Integration Tests', function () {
   this.slow(3000);
@@ -32,9 +32,8 @@ describe('Scan Integration Tests', function () {
     .it(
       'runs scan:rg --subscription [subscriptionId] -f ./test/rules.json',
       async ({stdout}) => {
-        const scanner = new Scanner();
-        await scanner.loadRulesFromFile('./test/rules.json');
-        const totalResourceGraphRules = scanner.rules.filter(
+        const rules = await getTestRules();
+        const totalResourceGraphRules = rules.filter(
           r => r.type === RuleType.ResourceGraph
         ).length;
         expect(stdout).to.contain(`${totalResourceGraphRules} scanned`);

--- a/test/azure/commands/scan.spec.ts
+++ b/test/azure/commands/scan.spec.ts
@@ -11,7 +11,7 @@ import {Scanner} from '../../../src/scanner';
 
 describe('Scan Integration Tests', function () {
   this.slow(3000);
-  this.timeout(5000);
+  this.timeout(20000);
   before(function () {
     if (!runIntegrationTests) {
       this.skip();
@@ -27,13 +27,13 @@ describe('Scan Integration Tests', function () {
       '--subscription',
       subscriptionId,
       '-f',
-      '../test/rules.json',
+      './test/rules.json',
     ])
     .it(
-      'runs scan:rg --subscription [subscriptionId] -f ../test/rules.json',
+      'runs scan:rg --subscription [subscriptionId] -f ./test/rules.json',
       async ({stdout}) => {
         const scanner = new Scanner();
-        await scanner.loadRulesFromFile('../test/rules.json');
+        await scanner.loadRulesFromFile('./test/rules.json');
         const totalResourceGraphRules = scanner.rules.filter(
           r => r.type === RuleType.ResourceGraph
         ).length;
@@ -49,10 +49,10 @@ describe('Scan Integration Tests', function () {
       '-g',
       resourceGroup,
       '-f',
-      '../test/rules.json',
+      './test/rules.json',
     ])
     .it(
-      'runs scan:rg -s [subscriptionId] -g [resourceGroup] -f ../test/rules.json',
+      'runs scan:rg -s [subscriptionId] -g [resourceGroup] -f ./test/rules.json',
       async ({stdout}) => {
         expect(stdout).to.contain(group1VNetId);
         expect(stdout).to.not.contain(group2VNetId);
@@ -69,10 +69,10 @@ describe('Scan Integration Tests', function () {
       '-g',
       resourceGroup2,
       '-f',
-      '../test/rules.json',
+      './test/rules.json',
     ])
     .it(
-      'runs scan:rg -s [subscriptionId] -g [resourceGroup1] -g [resourceGroup2] -f ../test/rules.json',
+      'runs scan:rg -s [subscriptionId] -g [resourceGroup1] -g [resourceGroup2] -f ./test/rules.json',
       async ({stdout}) => {
         expect(stdout).to.contain(group1VNetId);
         expect(stdout).to.contain(group2VNetId);
@@ -89,7 +89,7 @@ describe('Scan Integration Tests', function () {
       '-g',
       resourceGroup,
       '-f',
-      '../test/rules.json',
+      './test/rules.json',
     ])
     .it(
       'should warn user of nonexisting resource groups in the subscription',
@@ -100,7 +100,15 @@ describe('Scan Integration Tests', function () {
     );
   test
     .stdout()
-    .command(['scan:rg', '-s', subscriptionId, '-g', resourceGroup])
+    .command([
+      'scan:rg',
+      '-s',
+      subscriptionId,
+      '-g',
+      resourceGroup,
+      '-f',
+      './test/rules.json',
+    ])
     .it(
       'should find storage accounts with a private endpoint configured but the public endpoint is still enabled with a Resource Graph query',
       async ({stdout}) => {

--- a/test/azure/rules/armTemplate.spec.ts
+++ b/test/azure/rules/armTemplate.spec.ts
@@ -24,6 +24,7 @@ describe('ARM Template Rule', function () {
       name: 'accidental-public-storage',
       description:
         'Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled',
+      recommendation: 'recommendationLink',
       type: RuleType.ARM,
       evaluation: {
         query:
@@ -47,6 +48,7 @@ describe('ARM Template Rule', function () {
     const expectedResult = {
       ruleName: rule.name,
       description: rule.description,
+      recommendation: rule.recommendation,
       total: 1,
       resourceIds: [
         `subscriptions/${target.subscriptionId}/resourceGroups/${target.groupName}/providers/Microsoft.Storage/storageAccounts/${storageAccountName}`,

--- a/test/azure/rules/armTemplate.spec.ts
+++ b/test/azure/rules/armTemplate.spec.ts
@@ -68,15 +68,17 @@ describe('ARM Template Rule', function () {
       description: '',
       type: RuleType.ARM,
       recommendation:
-        'https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-1',
+        'https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#function-app-vnet-integration-misconfiguration',
       evaluation: {
         query: 'type == `Microsoft.Web/sites`',
-        request: {
-          operation: 'config/appsettings/list',
-          httpMethod: HttpMethods.POST,
-          query:
-            "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'",
-        },
+        request: [
+          {
+            operation: 'config/appsettings/list',
+            httpMethod: HttpMethods.POST,
+            query:
+              "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'",
+          },
+        ],
         and: [
           {
             query:

--- a/test/azure/rules/armTemplate.spec.ts
+++ b/test/azure/rules/armTemplate.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {ARMTemplateRule, RuleType} from '../../../src/rules';
+import {ARMTemplateRule, HttpMethods, RuleType} from '../../../src/rules';
 import {
   credential,
   resourceGroup,
@@ -73,6 +73,7 @@ describe('ARM Template Rule', function () {
         query: 'type == `Microsoft.Web/sites`',
         request: {
           operation: 'config/appsettings/list',
+          httpMethod: HttpMethods.POST,
           query:
             "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'",
         },

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -105,11 +105,12 @@ describe('Resource Graph Rule', function () {
     ]);
   });
 
-  it('can get the latest api version for a resource type', async () => {
+  it('can get the default api version for a resource type', async () => {
+    // the default api version may change, so probably not the best test. Is there another way we can test this?
     const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
-    const apiVersion = await testRule.getLatestApiVersion(resourceId, client);
-    expect(apiVersion).to.equal('2021-01-01-preview');
+    const apiVersion = await testRule.getDefaultApiVersion(resourceId, client);
+    expect(apiVersion).to.equal('2017-04-01');
   });
 
   it('can get a Request Url with a provided api version', async () => {
@@ -127,7 +128,7 @@ describe('Resource Graph Rule', function () {
   it('can get a Request Url when an api version is not provided', async () => {
     const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
-    const apiVersion = await testRule.getLatestApiVersion(resourceId, client);
+    const apiVersion = await testRule.getDefaultApiVersion(resourceId, client);
     const url = await testRule.getRequestUrl(resourceId, client);
     if (isRequestEvaluation(testRule.evaluation)) {
       expect(url).to.equal(

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -18,7 +18,7 @@ import {DefaultAzureCredential} from '@azure/identity';
 
 describe('Resource Graph Rule', function () {
   this.slow(6000);
-  this.timeout(10000);
+  this.timeout(15000);
 
   before(function () {
     if (!runIntegrationTests) {
@@ -168,8 +168,12 @@ describe('Resource Graph Rule', function () {
         'https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-1',
     });
     const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const shouldNotFindResourceId1 = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/azaTestNamespace`;
+    const shouldNotFindResourceId2 = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule2`;
     const result = await rule.execute(testTarget);
     expect(result.resourceIds).to.include(resourceId);
+    expect(result.resourceIds).to.not.include(shouldNotFindResourceId1);
+    expect(result.resourceIds).to.not.include(shouldNotFindResourceId2);
   });
 
   it('tests the Event Hub is not locked down rule 2', async () => {
@@ -191,7 +195,11 @@ describe('Resource Graph Rule', function () {
         'https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-2',
     });
     const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule2`;
+    const shouldNotFindResourceId1 = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/azaTestNamespace`;
+    const shouldNotFindResourceId2 = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const result = await rule.execute(testTarget);
     expect(result.resourceIds).to.include(resourceId);
+    expect(result.resourceIds).to.not.include(shouldNotFindResourceId1);
+    expect(result.resourceIds).to.not.include(shouldNotFindResourceId2);
   });
 });

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import {
+  isRequestEvaluation,
   ResourceGraphRule,
   ResourceGraphTarget,
   RuleType,
@@ -11,6 +12,7 @@ import {
   runIntegrationTests,
   subscriptionId,
 } from '..';
+import {DefaultAzureCredential} from '@azure/identity';
 
 describe('Resource Graph Rule', function () {
   this.slow(6000);
@@ -22,11 +24,34 @@ describe('Resource Graph Rule', function () {
     }
   });
 
+  const testRule = new ResourceGraphRule({
+    name: 'test-rule',
+    evaluation: {
+      query: "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
+      request: {
+        operation: 'networkRuleSets/default',
+        query:
+          'properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`',
+      },
+    },
+    recommendation: 'recommendationLink',
+    description: 'Test Rule',
+    type: RuleType.ResourceGraph,
+  });
+
+  const testTarget: ResourceGraphTarget = {
+    credential: new DefaultAzureCredential(),
+    subscriptionIds: [subscriptionId],
+    type: RuleType.ResourceGraph,
+  };
+
   it('can execute a resource graph rule and return a scan result', async () => {
     const rule = new ResourceGraphRule({
       name: 'test-rule',
       description: 'Intentional bad query',
-      query: "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'",
+      evaluation: {
+        query: "Resources | where type =~ 'Microsoft.Compute/virtualMachines2'",
+      },
       type: RuleType.ResourceGraph,
       recommendation: 'someLink',
     });
@@ -45,8 +70,8 @@ describe('Resource Graph Rule', function () {
     });
   });
   it('should return any non existing resource groups in a subscription', async () => {
-    const nonExistingGroup1 = `i-should-exist-${Date.now()}-1`;
-    const nonExistingGroup2 = `i-should-exist-${Date.now()}-2`;
+    const nonExistingGroup1 = `i-should-not-exist-${Date.now()}-1`;
+    const nonExistingGroup2 = `i-should-not-exist-${Date.now()}-2`;
     const groupNames = [
       nonExistingGroup1,
       nonExistingGroup2,
@@ -66,5 +91,70 @@ describe('Resource Graph Rule', function () {
     expect(nonExistingGroups).to.contain(nonExistingGroup2);
     expect(nonExistingGroups).to.not.contain(resourceGroup);
     expect(nonExistingGroups).to.not.contain(resourceGroup2);
+  });
+
+  it('can send a http request with a target and resource Id', async () => {
+    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const result = await testRule.sendRequest(testTarget, resourceId);
+    expect(result.parsedBody.properties).to.include.keys([
+      'defaultAction',
+      'ipRules',
+      'virtualNetworkRules',
+    ]);
+  });
+
+  it('can get the latest api version for a resource type', async () => {
+    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const client = await testRule.getResourceManagmentClient(resourceId);
+    const apiVersion = await testRule.getLatestApiVersion(resourceId, client);
+    expect(apiVersion).to.equal('2021-01-01-preview');
+  });
+
+  it('can get a valid api version from a HttpOperationResponse error response', async () => {
+    const errorMessage =
+      "No registered resource provider found for location 'eastus2' and API version '1' for type 'namespaces'. The supported api-versions are '2014-09-01, 2015-08-01, 2017-04-01, 2018-01-01-preview, 2021-01-01-preview'. The supported locations are 'australiaeast, australiasoutheast, centralus, eastus, eastus2, westus, westus2, northcentralus, southcentralus, westcentralus, eastasia, southeastasia, brazilsouth, japaneast, japanwest, northeurope, westeurope, centralindia, southindia, westindia, canadacentral, canadaeast, ukwest, uksouth, koreacentral, koreasouth, francecentral, southafricanorth, uaenorth, australiacentral, switzerlandnorth, germanywestcentral, norwayeast, jioindiawest'.";
+    const apiVersions = await testRule.getApiVersionFromError(errorMessage);
+    expect(apiVersions).to.equal('2018-01-01-preview');
+  });
+
+  it('throws an error when it cannot retrive a valid api version', async () => {
+    const errorMessage =
+      "No registered resource provider found for location 'eastus2' and API version '2020-02-01' for type 'namespaces'. The supported api-versions are ', , , ,'. The supported locations are 'australiaeast, australiasoutheast, centralus, eastus, eastus2, westus, westus2, northcentralus, southcentralus, westcentralus, eastasia, southeastasia, brazilsouth, japaneast, japanwest, northeurope, westeurope, centralindia, southindia, westindia, canadacentral, canadaeast, ukwest, uksouth, koreacentral, koreasouth, francecentral, southafricanorth, uaenorth, australiacentral, switzerlandnorth, germanywestcentral, norwayeast, jioindiawest'.";
+    const iThrowError = () => testRule.getApiVersionFromError(errorMessage);
+    expect(iThrowError).throw(Error, 'Unable to find a valid apiVersion');
+  });
+
+  it('can getElementFromId', () => {
+    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const subscription = testRule.getElementFromId('subscription', resourceId);
+    const provider = testRule.getElementFromId('provider', resourceId);
+    const resourceType = testRule.getElementFromId('resourceType', resourceId);
+    expect(subscription).to.equal(subscriptionId);
+    expect(provider).to.equal('Microsoft.EventHub');
+    expect(resourceType).to.equal('namespaces');
+  });
+
+  it('can get a Request Url with a provided apiVersion', async () => {
+    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const client = await testRule.getResourceManagmentClient(resourceId);
+    const apiVersion = '2018-01-01-preview';
+    const url = await testRule.getRequestUrl(resourceId, client, apiVersion);
+    if (isRequestEvaluation(testRule.evaluation)) {
+      expect(url).to.equal(
+        `https://management.azure.com/${resourceId}/${testRule.evaluation.request.operation}?api-version=${apiVersion}`
+      );
+    }
+  });
+
+  it('can get a Request Url when an apiVersion is not provided', async () => {
+    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const client = await testRule.getResourceManagmentClient(resourceId);
+    const apiVersion = await testRule.getLatestApiVersion(resourceId, client);
+    const url = await testRule.getRequestUrl(resourceId, client);
+    if (isRequestEvaluation(testRule.evaluation)) {
+      expect(url).to.equal(
+        `https://management.azure.com/${resourceId}/${testRule.evaluation.request.operation}?api-version=${apiVersion}`
+      );
+    }
   });
 });

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {
   HttpMethods,
   isRequestEvaluation,
+  RequestEvaluation,
   ResourceGraphRule,
   ResourceGraphTarget,
   RuleType,
@@ -117,7 +118,12 @@ describe('Resource Graph Rule', function () {
     const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = '2018-01-01-preview';
-    const url = await testRule.getRequestUrl(resourceId, client, apiVersion);
+    const url = await testRule.getRequestUrl(
+      resourceId,
+      testRule.evaluation as RequestEvaluation,
+      client,
+      apiVersion
+    );
     if (isRequestEvaluation(testRule.evaluation)) {
       expect(url).to.equal(
         `https://management.azure.com/${resourceId}/${testRule.evaluation.request.operation}?api-version=${apiVersion}`
@@ -129,11 +135,17 @@ describe('Resource Graph Rule', function () {
     const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = await testRule.getDefaultApiVersion(resourceId, client);
-    const url = await testRule.getRequestUrl(resourceId, client);
+    const url = await testRule.getRequestUrl(
+      resourceId,
+      testRule.evaluation as RequestEvaluation,
+      client
+    );
     if (isRequestEvaluation(testRule.evaluation)) {
       expect(url).to.equal(
         `https://management.azure.com/${resourceId}/${testRule.evaluation.request.operation}?api-version=${apiVersion}`
       );
+    } else {
+      throw Error('The test rule is not a request evaluation');
     }
   });
 

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import {
+  HttpMethods,
   isRequestEvaluation,
   ResourceGraphRule,
   ResourceGraphTarget,
@@ -30,6 +31,7 @@ describe('Resource Graph Rule', function () {
       query: "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
       request: {
         operation: 'networkRuleSets/default',
+        httpMethod: HttpMethods.GET,
         query:
           'properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`',
       },

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -118,12 +118,7 @@ describe('Resource Graph Rule', function () {
     const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = '2018-01-01-preview';
-    const url = await testRule.getRequestUrl(
-      resourceId,
-      testRule.evaluation as RequestEvaluation,
-      client,
-      apiVersion
-    );
+    const url = await testRule.getRequestUrl(resourceId, client, apiVersion);
     if (isRequestEvaluation(testRule.evaluation)) {
       expect(url).to.equal(
         `https://management.azure.com/${resourceId}/${testRule.evaluation.request.operation}?api-version=${apiVersion}`
@@ -135,11 +130,7 @@ describe('Resource Graph Rule', function () {
     const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = await testRule.getDefaultApiVersion(resourceId, client);
-    const url = await testRule.getRequestUrl(
-      resourceId,
-      testRule.evaluation as RequestEvaluation,
-      client
-    );
+    const url = await testRule.getRequestUrl(resourceId, client);
     if (isRequestEvaluation(testRule.evaluation)) {
       expect(url).to.equal(
         `https://management.azure.com/${resourceId}/${testRule.evaluation.request.operation}?api-version=${apiVersion}`

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -97,7 +97,7 @@ describe('Resource Graph Rule', function () {
   });
 
   it('can send a http request with a target and resource Id', async () => {
-    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const result = await testRule.sendRequest(testTarget, resourceId);
     expect(result.parsedBody.properties).to.include.keys([
       'defaultAction',
@@ -108,14 +108,14 @@ describe('Resource Graph Rule', function () {
 
   it('can get the default api version for a resource type', async () => {
     // the default api version may change, so probably not the best test. Is there another way we can test this?
-    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = await testRule.getDefaultApiVersion(resourceId, client);
     expect(apiVersion).to.equal('2017-04-01');
   });
 
   it('can get a Request Url with a provided api version', async () => {
-    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = '2018-01-01-preview';
     const url = await testRule.getRequestUrl(
@@ -132,7 +132,7 @@ describe('Resource Graph Rule', function () {
   });
 
   it('can get a Request Url when an api version is not provided', async () => {
-    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = await testRule.getDefaultApiVersion(resourceId, client);
     const url = await testRule.getRequestUrl(

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -2,7 +2,6 @@ import {expect} from 'chai';
 import {
   HttpMethods,
   isRequestEvaluation,
-  RequestEvaluation,
   ResourceGraphRule,
   ResourceGraphTarget,
   RuleType,

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -135,4 +135,50 @@ describe('Resource Graph Rule', function () {
       );
     }
   });
+
+  it('tests the Event Hub is not locked down rule 1', async () => {
+    const rule = new ResourceGraphRule({
+      name: 'event-hubs-not-locked-down-1',
+      description:
+        'Finds Event Hubs with a network rule set having zero IP and virtual network rules and the defaultAction is Deny.',
+      type: RuleType.ResourceGraph,
+      evaluation: {
+        query: "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
+        request: {
+          operation: 'networkRuleSets/default',
+          httpMethod: HttpMethods.GET,
+          query:
+            'properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`',
+        },
+      },
+      recommendation:
+        'https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-1',
+    });
+    const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const result = await rule.execute(testTarget);
+    expect(result.resourceIds).to.include(resourceId);
+  });
+
+  it('tests the Event Hub is not locked down rule 2', async () => {
+    const rule = new ResourceGraphRule({
+      name: 'event-hubs-not-locked-down-1',
+      description:
+        "Finds Event Hubs with a network rule set having one or more IP and virtual network rules for the namespace but the defaultAction is not set to 'Deny'",
+      type: RuleType.ResourceGraph,
+      evaluation: {
+        query: "Resources | where type=~ 'Microsoft.EventHub/namespaces'",
+        request: {
+          operation: 'networkRuleSets/default',
+          httpMethod: HttpMethods.GET,
+          query:
+            'properties.defaultAction == `Allow` && (length(properties.ipRules) > `0` || length(properties.virtualNetworkRules) > `0`)',
+        },
+      },
+      recommendation:
+        'https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#event-hubs-not-locked-down-2',
+    });
+    const resourceId = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule2`;
+    const result = await rule.execute(testTarget);
+    expect(result.resourceIds).to.include(resourceId);
+  });
 });

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -110,31 +110,7 @@ describe('Resource Graph Rule', function () {
     expect(apiVersion).to.equal('2021-01-01-preview');
   });
 
-  it('can get a valid api version from a HttpOperationResponse error response', async () => {
-    const errorMessage =
-      "No registered resource provider found for location 'eastus2' and API version '1' for type 'namespaces'. The supported api-versions are '2014-09-01, 2015-08-01, 2017-04-01, 2018-01-01-preview, 2021-01-01-preview'. The supported locations are 'australiaeast, australiasoutheast, centralus, eastus, eastus2, westus, westus2, northcentralus, southcentralus, westcentralus, eastasia, southeastasia, brazilsouth, japaneast, japanwest, northeurope, westeurope, centralindia, southindia, westindia, canadacentral, canadaeast, ukwest, uksouth, koreacentral, koreasouth, francecentral, southafricanorth, uaenorth, australiacentral, switzerlandnorth, germanywestcentral, norwayeast, jioindiawest'.";
-    const apiVersions = await testRule.getApiVersionFromError(errorMessage);
-    expect(apiVersions).to.equal('2018-01-01-preview');
-  });
-
-  it('throws an error when it cannot retrive a valid api version', async () => {
-    const errorMessage =
-      "No registered resource provider found for location 'eastus2' and API version '2020-02-01' for type 'namespaces'. The supported api-versions are ', , , ,'. The supported locations are 'australiaeast, australiasoutheast, centralus, eastus, eastus2, westus, westus2, northcentralus, southcentralus, westcentralus, eastasia, southeastasia, brazilsouth, japaneast, japanwest, northeurope, westeurope, centralindia, southindia, westindia, canadacentral, canadaeast, ukwest, uksouth, koreacentral, koreasouth, francecentral, southafricanorth, uaenorth, australiacentral, switzerlandnorth, germanywestcentral, norwayeast, jioindiawest'.";
-    const iThrowError = () => testRule.getApiVersionFromError(errorMessage);
-    expect(iThrowError).throw(Error, 'Unable to find a valid apiVersion');
-  });
-
-  it('can getElementFromId', () => {
-    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
-    const subscription = testRule.getElementFromId('subscription', resourceId);
-    const provider = testRule.getElementFromId('provider', resourceId);
-    const resourceType = testRule.getElementFromId('resourceType', resourceId);
-    expect(subscription).to.equal(subscriptionId);
-    expect(provider).to.equal('Microsoft.EventHub');
-    expect(resourceType).to.equal('namespaces');
-  });
-
-  it('can get a Request Url with a provided apiVersion', async () => {
+  it('can get a Request Url with a provided api version', async () => {
     const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = '2018-01-01-preview';
@@ -146,7 +122,7 @@ describe('Resource Graph Rule', function () {
     }
   });
 
-  it('can get a Request Url when an apiVersion is not provided', async () => {
+  it('can get a Request Url when an api version is not provided', async () => {
     const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const client = await testRule.getResourceManagmentClient(resourceId);
     const apiVersion = await testRule.getLatestApiVersion(resourceId, client);

--- a/test/azure/scanner.spec.ts
+++ b/test/azure/scanner.spec.ts
@@ -19,7 +19,7 @@ describe('Scanner', function () {
       credential: new DefaultAzureCredential(),
     };
     const scanner = new Scanner();
-    await scanner.loadRulesFromFile('../test/rules.json');
+    await scanner.loadRulesFromFile('./test/rules.json');
     const totalResourceGraphRules = scanner.rules.filter(
       r => r.type === RuleType.ResourceGraph
     ).length;

--- a/test/azure/scanner.spec.ts
+++ b/test/azure/scanner.spec.ts
@@ -3,10 +3,11 @@ import {Scanner} from '../../src/scanner';
 import {runIntegrationTests, subscriptionId} from '.';
 import {ResourceGraphTarget, RuleType} from '../../src/rules';
 import {DefaultAzureCredential} from '@azure/identity';
+import {getTestRules} from '..';
 
 describe('Scanner', function () {
   this.slow(5000);
-  this.timeout(8000);
+  this.timeout(15000);
   before(function () {
     if (!runIntegrationTests) {
       this.skip();
@@ -19,11 +20,11 @@ describe('Scanner', function () {
       credential: new DefaultAzureCredential(),
     };
     const scanner = new Scanner();
-    await scanner.loadRulesFromFile('./test/rules.json');
-    const totalResourceGraphRules = scanner.rules.filter(
+    const rules = await getTestRules();
+    const totalResourceGraphRules = rules.filter(
       r => r.type === RuleType.ResourceGraph
     ).length;
-    const rgResults = await scanner.scan(target);
+    const rgResults = await scanner.scan(target, './test/rules.json');
     assert.equal(rgResults.length, totalResourceGraphRules);
     rgResults.forEach(r => {
       assert.containsAllKeys(r, [

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,9 @@
+import {Scanner} from '../src/scanner';
+import {Rule} from '../src/rules';
+
+let rules: Rule[];
+export async function getTestRules() {
+  if (rules) return rules;
+  const scanner = new Scanner();
+  return await scanner.getRulesFromFile('./test/rules.json');
+}

--- a/test/rules.json
+++ b/test/rules.json
@@ -3,13 +3,28 @@
     "name": "bad-query",
     "description": "Should return no results",
     "type": "ResourceGraph",
-    "query": "Resources | where type =~ 'Microsoft.Network/virtualNetworks2'"
+    "recommendation": "recommendationLink",
+    "evaluation": {
+      "query": "Resources | where type =~ 'Microsoft.Network/virtualNetworks2'"
+    }
   },
   {
     "name": "get-vnets",
     "description": "Gets all vnets in a subscription",
     "type": "ResourceGraph",
-    "query": "Resources | where type =~ 'Microsoft.Network/virtualNetworks'"
+    "recommendation": "recommendationLink",
+    "evaluation": {
+      "query": "Resources | where type =~ 'Microsoft.Network/virtualNetworks'"
+    }
+  },
+  {
+    "name": "accidental-public-storage",
+    "description": "Finds Storage Accounts with a Private Endpoint configured but the public endpoint is still enabled",
+    "type": "ResourceGraph",
+    "evaluation": {
+      "query": "Resources | where type=~ 'Microsoft.Storage/storageAccounts' and isnotempty(properties.privateEndpointConnections[0]) and properties.networkAcls.defaultAction=~ 'Allow'"
+    },
+    "recommendation": "https://github.com/noelbundick/config-analyzer/blob/main/docs/built-in-rules.md#accidental-public-storage"
   },
   {
     "name": "dummy-rule-1",

--- a/test/unit/rules/armTemplate.spec.ts
+++ b/test/unit/rules/armTemplate.spec.ts
@@ -6,6 +6,7 @@ import {
   ARMTarget,
   ARMTemplateRule,
   filterAsync,
+  HttpMethods,
   RuleType,
 } from '../../../src/rules';
 import {ResourceManagementClient} from '@azure/arm-resources';
@@ -165,6 +166,7 @@ describe('ARM Template Rule', () => {
       query: '',
       request: {
         query: '',
+        httpMethod: HttpMethods.POST,
         operation: 'path/for/operation',
       },
     };

--- a/test/unit/rules/armTemplate.spec.ts
+++ b/test/unit/rules/armTemplate.spec.ts
@@ -7,6 +7,7 @@ import {
   ARMTemplateRule,
   filterAsync,
   HttpMethods,
+  RequestEvaluationObject,
   RuleType,
 } from '../../../src/rules';
 import {ResourceManagementClient} from '@azure/arm-resources';
@@ -164,18 +165,20 @@ describe('ARM Template Rule', () => {
   it('can build a request Url for the sendRequest method', () => {
     const evaluation = {
       query: '',
-      request: {
-        query: '',
-        httpMethod: HttpMethods.POST,
-        operation: 'path/for/operation',
-      },
+      request: [
+        {
+          query: '',
+          httpMethod: HttpMethods.POST,
+          operation: 'path/for/operation',
+        },
+      ],
     };
     const result = rule.getRequestUrl(
       testARMTarget,
       template.resources[0],
-      evaluation
+      evaluation.request[0] as RequestEvaluationObject
     );
-    const expectedResult = `https://management.azure.com/subscriptions/${testARMTarget.subscriptionId}/resourceGroups/${testARMTarget.groupName}/providers/${template.resources[0].type}/${template.resources[0].name}/${evaluation.request.operation}?api-version=${template.resources[0].apiVersion}`;
+    const expectedResult = `https://management.azure.com/subscriptions/${testARMTarget.subscriptionId}/resourceGroups/${testARMTarget.groupName}/providers/${template.resources[0].type}/${template.resources[0].name}/${evaluation.request[0].operation}?api-version=${template.resources[0].apiVersion}`;
     expect(result).to.equal(expectedResult);
   });
 

--- a/test/unit/rules/armTemplate.spec.ts
+++ b/test/unit/rules/armTemplate.spec.ts
@@ -16,6 +16,7 @@ describe('ARM Template Rule', () => {
     type: RuleType.ARM,
     name: 'test-rule',
     description: 'use for testing rule methods',
+    recommendation: 'recommendationLink',
     evaluation: {
       query:
         'type == `Microsoft.Storage/storageAccounts` && properties.networkAcls.defaultAction == `Allow`',
@@ -107,6 +108,7 @@ describe('ARM Template Rule', () => {
       description:
         "used for testing a rule with an 'and' evalutation - first eval should find a resource and the second eval excludes it from results",
       type: RuleType.ARM,
+      recommendation: 'recommendationLink',
       evaluation: {
         query:
           'type == `Microsoft.Storage/storageAccounts` && name == `storageAccountName`',
@@ -122,6 +124,7 @@ describe('ARM Template Rule', () => {
       ruleName: rule.name,
       description: rule.description,
       total: 0,
+      recommendation: rule.recommendation,
       resourceIds: [],
     };
     const resultShouldPass = await rule.execute(testARMTarget);
@@ -134,6 +137,7 @@ describe('ARM Template Rule', () => {
       description:
         "used for testing a rule with an 'and' evaluation - first eval should find a resource and should also find a resource",
       type: RuleType.ARM,
+      recommendation: 'recommendationLink',
       evaluation: {
         query:
           'type == `Microsoft.Storage/storageAccounts` && name == `storageAccountName`',
@@ -149,6 +153,7 @@ describe('ARM Template Rule', () => {
       ruleName: rule.name,
       description: rule.description,
       total: 1,
+      recommendation: rule.recommendation,
       resourceIds: [rule.getResourceId(template.resources[0], testARMTarget)],
     };
     const resultShouldPass = await rule.execute(testARMTarget);

--- a/test/unit/rules/azureResourceGraph.spec.ts
+++ b/test/unit/rules/azureResourceGraph.spec.ts
@@ -3,7 +3,6 @@ import {HttpHeadersLike, WebResourceLike} from '@azure/ms-rest-js';
 import {expect} from 'chai';
 
 import {ResourceGraphRule, RuleType} from '../../../src/rules';
-import {resourceGroup, subscriptionId} from '../../azure';
 
 describe('Resource Graph Rule', () => {
   const mockResourcesResponse = (): ResourceGraphModels.ResourcesResponse => {
@@ -103,11 +102,13 @@ describe('Resource Graph Rule', () => {
   });
 
   it('can get the provider, subscription id, and resource type From a resource id', () => {
-    const resourceId = `subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const testSubId = '0000-000-000-000';
+    const testResourceGroup = 'aza-demo';
+    const resourceId = `subscriptions/${testSubId}/resourceGroups/${testResourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const subscription = rule.getElementFromId('subscription', resourceId);
     const provider = rule.getElementFromId('provider', resourceId);
     const resourceType = rule.getElementFromId('resourceType', resourceId);
-    expect(subscription).to.equal(subscriptionId);
+    expect(subscription).to.equal(testSubId);
     expect(provider).to.equal('Microsoft.EventHub');
     expect(resourceType).to.equal('namespaces');
   });

--- a/test/unit/rules/azureResourceGraph.spec.ts
+++ b/test/unit/rules/azureResourceGraph.spec.ts
@@ -103,8 +103,7 @@ describe('Resource Graph Rule', () => {
 
   it('can get the provider, subscription id, and resource type From a resource id', () => {
     const testSubId = '0000-000-000-000';
-    const testResourceGroup = 'aza-demo';
-    const resourceId = `subscriptions/${testSubId}/resourceGroups/${testResourceGroup}/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
+    const resourceId = `/subscriptions/${testSubId}/resourceGroups/aza-demo/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
     const subscription = rule.getElementFromId('subscription', resourceId);
     const provider = rule.getElementFromId('provider', resourceId);
     const resourceType = rule.getElementFromId('resourceType', resourceId);

--- a/test/unit/rules/azureResourceGraph.spec.ts
+++ b/test/unit/rules/azureResourceGraph.spec.ts
@@ -25,40 +25,31 @@ describe('Resource Graph Rule', () => {
   };
   const rule = new ResourceGraphRule({
     name: 'test-rule',
-    query: 'mock query',
+    evaluation: {
+      query: 'mock query',
+    },
+    recommendation: 'recommendationLink',
     description: 'Intentional bad query',
     type: RuleType.ResourceGraph,
   });
   it('can produce a scan result', () => {
-    const scanResult = rule.toScanResult(mockResourcesResponse());
+    const resourceIds = rule.convertResourcesResponseToIds(
+      mockResourcesResponse()
+    );
+    const scanResult = rule.toScanResult(resourceIds);
     expect(scanResult).to.deep.equal({
       ruleName: rule.name,
       description: rule.description,
       total: 1,
-      resourceIds: ['mockResourceId'],
-    });
-  });
-  it('can produce a scan result wtih a documentation link', () => {
-    const rule = new ResourceGraphRule({
-      name: 'test-rule',
-      query: 'mock query',
-      description: 'Intentional bad query',
-      recommendation: 'testLink',
-      type: RuleType.ResourceGraph,
-    });
-    const scanResult = rule.toScanResult(mockResourcesResponse());
-    expect(scanResult).to.deep.equal({
-      ruleName: rule.name,
-      description: rule.description,
       recommendation: rule.recommendation,
-      total: 1,
       resourceIds: ['mockResourceId'],
     });
   });
   it("should throw an errow if the 'id' column is not returned from Resource Graph", () => {
     const resourcesResponse = mockResourcesResponse();
     resourcesResponse.data.columns = [];
-    const iThrowError = () => rule.toScanResult(resourcesResponse);
+    const iThrowError = () =>
+      rule.convertResourcesResponseToIds(resourcesResponse);
     expect(iThrowError).to.throw(
       Error,
       'Id column was not returned from Azure Resource Graph'
@@ -67,7 +58,10 @@ describe('Resource Graph Rule', () => {
   it('can modify a query to target resource groups', () => {
     const rule = new ResourceGraphRule({
       name: 'test-rule',
-      query: "Resources | where type =~ 'Microsoft.Network/virtualNetworks'",
+      evaluation: {
+        query: "Resources | where type =~ 'Microsoft.Network/virtualNetworks'",
+      },
+      recommendation: 'recommendationLink',
       description: 'Intentional bad query',
       type: RuleType.ResourceGraph,
     });
@@ -80,7 +74,10 @@ describe('Resource Graph Rule', () => {
   it('should throw an error when modfiying an invalid query', () => {
     const rule = new ResourceGraphRule({
       name: 'test-rule',
-      query: "where type =~ 'Microsoft.Network/virtualNetworks'",
+      evaluation: {
+        query: "where type =~ 'Microsoft.Network/virtualNetworks'",
+      },
+      recommendation: 'recommendationLink',
       description: 'Does not include the inital table name',
       type: RuleType.ResourceGraph,
     });

--- a/test/unit/scanner.spec.ts
+++ b/test/unit/scanner.spec.ts
@@ -1,15 +1,12 @@
 import {assert} from 'chai';
-import {Scanner} from '../../src/scanner';
-import * as path from 'path';
+import {getTestRules} from '..';
 
 describe('Scanner', function () {
   this.slow(5000);
   this.timeout(8000);
   it('can load rules from a JSON file', async () => {
-    const scanner = new Scanner();
-    const absPath = path.join(__dirname, '../rules.json');
-    await scanner.loadRulesFromFile(absPath);
-    for (const r of scanner.rules) {
+    const rules = await getTestRules();
+    for (const r of rules) {
       assert.containsAllKeys(r, ['name', 'description', 'type']);
     }
   });


### PR DESCRIPTION
closes #89 
closes #91 

- fixes test rules file bug *didn't catch this earlier*
     - adjusts scanner class so rules are not a property of the class and are loaded in the scan method instead 
- adds request array to resource graph rule
    - it is now an evaluation object 
    - it looks like the ARM template rule but there is not functionality for 'and' evals yet.
- changes request to be an array for arm rules 
- moves evaluation interfaces to src/rules/index.ts 
- recommendation is now required in both types of rules
- adds httpMethod to request to provide support for GET and POST requests
- adds 2 EventHub rules for Resource Graph
- adds resource graph function app rule
- adds tests


I was trying to write a Resource Graph rule for the function app rule, but this is not possible without adding functionality for multiple requests. We should add a feature to support the request evaluation as an array so multiple call can be evaluated.