### PR TITLE
RG request patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@azure/arm-resourcegraph": "^3.0.0",
     "@azure/arm-resources": "^4.0.0",
+    "@azure/core-http": "^1.2.4",
     "@azure/identity": "^1.2.3",
     "@azure/ms-rest-js": "^2.2.3",
     "@oclif/command": "^1.8.0",

--- a/src/rules/armTemplate.ts
+++ b/src/rules/armTemplate.ts
@@ -154,10 +154,10 @@ export class ARMTemplateRule implements BaseRule<ARMTarget> {
     request: RequestEvaluationObject
   ) {
     if (!isRequestEvaluation(this.evaluation)) {
-      throw Error('A valid request evalutation was not found');
+      throw Error('A valid request evaluation was not found');
     }
     const token = await target.credential.getToken(
-      'https://graph.microsoft.com/.default'
+      'https://management.azure.com/.default'
     );
     const options = {
       url: this.getRequestUrl(target, resource, request),

--- a/src/rules/armTemplate.ts
+++ b/src/rules/armTemplate.ts
@@ -11,7 +11,7 @@ import {
   isAndEvaluation,
   HttpMethods,
   filterAsync,
-  RequestEvaluationObject,
+  Request,
   everyAsync,
 } from '.';
 import {AzureIdentityCredentialAdapter} from '../azure';
@@ -151,7 +151,7 @@ export class ARMTemplateRule implements BaseRule<ARMTarget> {
   async sendRequest(
     target: ARMTarget,
     resource: ARMResource,
-    request: RequestEvaluationObject
+    request: Request
   ) {
     if (!isRequestEvaluation(this.evaluation)) {
       throw Error('A valid request evaluation was not found');
@@ -170,11 +170,7 @@ export class ARMTemplateRule implements BaseRule<ARMTarget> {
     return await target.client.sendRequest(options);
   }
 
-  getRequestUrl(
-    target: ARMTarget,
-    resource: ARMResource,
-    request: RequestEvaluationObject
-  ) {
+  getRequestUrl(target: ARMTarget, resource: ARMResource, request: Request) {
     return `https://management.azure.com/subscriptions/${target.subscriptionId}/resourceGroups/${target.groupName}/providers/${resource.type}/${resource.name}/${request.operation}?api-version=${resource.apiVersion}`;
   }
 

--- a/src/rules/armTemplate.ts
+++ b/src/rules/armTemplate.ts
@@ -1,5 +1,6 @@
 import {ResourceManagementClient} from '@azure/arm-resources';
 import {TokenCredential} from '@azure/identity';
+import {HttpMethods} from '@azure/core-http';
 import JMESPath = require('jmespath');
 import Handlebars = require('handlebars');
 
@@ -9,7 +10,6 @@ import {
   Evaluation,
   isRequestEvaluation,
   isAndEvaluation,
-  HttpMethods,
   filterAsync,
   Request,
   everyAsync,

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -129,7 +129,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
       throw Error('A valid request evaluation was not found');
     }
     const token = await target.credential.getToken(
-      'https://graph.microsoft.com/.default'
+      'https://management.azure.com/.default'
     );
     const resourceManagementClient = await this.getResourceManagmentClient(
       resourceId

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -1,6 +1,7 @@
 import {ResourceGraphModels} from '@azure/arm-resourcegraph';
 import {ResourceManagementClient} from '@azure/arm-resources';
 import {DefaultAzureCredential, TokenCredential} from '@azure/identity';
+import {HttpMethods} from '@azure/core-http';
 import JMESPath = require('jmespath');
 
 import {
@@ -8,7 +9,6 @@ import {
   RuleType,
   Evaluation,
   isRequestEvaluation,
-  HttpMethods,
   filterAsync,
   everyAsync,
   Request,

--- a/src/rules/azureResourceGraph.ts
+++ b/src/rules/azureResourceGraph.ts
@@ -11,7 +11,7 @@ import {
   HttpMethods,
   filterAsync,
   everyAsync,
-  RequestEvaluationObject,
+  Request,
   QueryOption,
 } from '.';
 import {AzureClient, AzureIdentityCredentialAdapter} from '../azure';
@@ -123,7 +123,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
   async sendRequest(
     target: ResourceGraphTarget,
     resourceId: string,
-    request: RequestEvaluationObject
+    request: Request
   ) {
     if (!isRequestEvaluation(this.evaluation)) {
       throw Error('A valid request evaluation was not found');
@@ -232,7 +232,7 @@ export class ResourceGraphRule implements BaseRule<ResourceGraphTarget> {
   async getRequestUrl(
     resourceId: string,
     client: ResourceManagementClient,
-    request: RequestEvaluationObject,
+    request: Request,
     apiVersion?: string
   ) {
     const fullResourceId = `${resourceId}/${request.operation}`;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -34,10 +34,10 @@ type AndEvaluation = BaseEvaluation & {
 };
 
 export type RequestEvaluation = BaseEvaluation & {
-  request: Array<RequestEvaluationObject>;
+  request: Array<Request>;
 };
 
-export type RequestEvaluationObject = {
+export type Request = {
   operation: string;
   httpMethod: HttpMethods;
   query: string | QueryOption.EXISTS;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,13 +1,7 @@
 import {ScanResult} from '../scanner';
 import {ARMTarget, ARMTemplateRule} from './armTemplate';
 import {ResourceGraphRule, ResourceGraphTarget} from './azureResourceGraph';
-
-// needed for sendRequest method
-// from @azure/core-http => https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-core-http/1.2.4/globals.html#httpmethods
-export enum HttpMethods {
-  POST = 'POST',
-  GET = 'GET',
-}
+import {HttpMethods} from '@azure/core-http';
 
 export enum RuleType {
   ResourceGraph = 'ResourceGraph',

--- a/test/azure/commands/scan.spec.ts
+++ b/test/azure/commands/scan.spec.ts
@@ -6,8 +6,8 @@ import {
   runIntegrationTests,
   subscriptionId,
 } from '..';
-import {getTestRules} from '../..';
 import {RuleType} from '../../../src/rules';
+import {Scanner} from '../../../src/scanner';
 
 describe('Scan Integration Tests', function () {
   this.slow(3000);
@@ -32,7 +32,8 @@ describe('Scan Integration Tests', function () {
     .it(
       'runs scan:rg --subscription [subscriptionId] -f ./test/rules.json',
       async ({stdout}) => {
-        const rules = await getTestRules();
+        const scanner = new Scanner();
+        const rules = await scanner.getRulesFromFile('./test/rules.json');
         const totalResourceGraphRules = rules.filter(
           r => r.type === RuleType.ResourceGraph
         ).length;

--- a/test/azure/rules/armTemplate.spec.ts
+++ b/test/azure/rules/armTemplate.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {ARMTemplateRule, HttpMethods, RuleType} from '../../../src/rules';
+import {ARMTemplateRule, RuleType} from '../../../src/rules';
 import {
   credential,
   resourceGroup,
@@ -74,7 +74,7 @@ describe('ARM Template Rule', function () {
         request: [
           {
             operation: 'config/appsettings/list',
-            httpMethod: HttpMethods.POST,
+            httpMethod: 'POST',
             query:
               "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'",
           },

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {
-  HttpMethods,
   isRequestEvaluation,
   Request,
   ResourceGraphRule,
@@ -33,7 +32,7 @@ describe('Resource Graph Rule', function () {
       request: [
         {
           operation: 'networkRuleSets/default',
-          httpMethod: HttpMethods.GET,
+          httpMethod: 'GET',
           query:
             'properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`',
         },
@@ -175,7 +174,7 @@ describe('Resource Graph Rule', function () {
         request: [
           {
             operation: 'networkRuleSets/default',
-            httpMethod: HttpMethods.GET,
+            httpMethod: 'GET',
             query:
               'properties.defaultAction == `Deny` && length(properties.ipRules) == `0` && length(properties.virtualNetworkRules) == `0`',
           },
@@ -204,7 +203,7 @@ describe('Resource Graph Rule', function () {
         request: [
           {
             operation: 'networkRuleSets/default',
-            httpMethod: HttpMethods.GET,
+            httpMethod: 'GET',
             query:
               'properties.defaultAction == `Allow` && (length(properties.ipRules) > `0` || length(properties.virtualNetworkRules) > `0`)',
           },
@@ -236,12 +235,12 @@ describe('Resource Graph Rule', function () {
         request: [
           {
             operation: 'virtualNetworkConnections',
-            httpMethod: HttpMethods.GET,
+            httpMethod: 'GET',
             query: 'exists',
           },
           {
             operation: 'config/appsettings/list',
-            httpMethod: HttpMethods.POST,
+            httpMethod: 'POST',
             query:
               "properties.WEBSITE_DNS_SERVER != '168.63.129.16' || properties.WEBSITE_VNET_ROUTE_ALL != '1'",
           },

--- a/test/azure/rules/azureResourceGraph.spec.ts
+++ b/test/azure/rules/azureResourceGraph.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {
   HttpMethods,
   isRequestEvaluation,
-  RequestEvaluationObject,
+  Request,
   ResourceGraphRule,
   ResourceGraphTarget,
   RuleType,
@@ -106,7 +106,7 @@ describe('Resource Graph Rule', function () {
     const result = await testRule.sendRequest(
       testTarget,
       resourceId,
-      testRule.evaluation.request[0] as RequestEvaluationObject
+      testRule.evaluation.request[0] as Request
     );
     expect(result.parsedBody.properties).to.include.keys([
       'defaultAction',
@@ -133,7 +133,7 @@ describe('Resource Graph Rule', function () {
     const url = await testRule.getRequestUrl(
       resourceId,
       client,
-      testRule.evaluation.request[0] as RequestEvaluationObject,
+      testRule.evaluation.request[0] as Request,
       apiVersion
     );
     if (isRequestEvaluation(testRule.evaluation)) {
@@ -153,7 +153,7 @@ describe('Resource Graph Rule', function () {
     const url = await testRule.getRequestUrl(
       resourceId,
       client,
-      testRule.evaluation.request[0] as RequestEvaluationObject
+      testRule.evaluation.request[0] as Request
     );
     if (isRequestEvaluation(testRule.evaluation)) {
       expect(url).to.equal(

--- a/test/azure/scanner.spec.ts
+++ b/test/azure/scanner.spec.ts
@@ -3,7 +3,6 @@ import {Scanner} from '../../src/scanner';
 import {runIntegrationTests, subscriptionId} from '.';
 import {ResourceGraphTarget, RuleType} from '../../src/rules';
 import {DefaultAzureCredential} from '@azure/identity';
-import {getTestRules} from '..';
 
 describe('Scanner', function () {
   this.slow(5000);
@@ -20,7 +19,7 @@ describe('Scanner', function () {
       credential: new DefaultAzureCredential(),
     };
     const scanner = new Scanner();
-    const rules = await getTestRules();
+    const rules = await scanner.getRulesFromFile('./test/rules.json');
     const totalResourceGraphRules = rules.filter(
       r => r.type === RuleType.ResourceGraph
     ).length;

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,9 +1,0 @@
-import {Scanner} from '../src/scanner';
-import {Rule} from '../src/rules';
-
-let rules: Rule[];
-export async function getTestRules() {
-  if (rules) return rules;
-  const scanner = new Scanner();
-  return await scanner.getRulesFromFile('./test/rules.json');
-}

--- a/test/unit/rules/armTemplate.spec.ts
+++ b/test/unit/rules/armTemplate.spec.ts
@@ -6,7 +6,6 @@ import {
   ARMTarget,
   ARMTemplateRule,
   filterAsync,
-  HttpMethods,
   Request,
   RuleType,
 } from '../../../src/rules';
@@ -168,7 +167,7 @@ describe('ARM Template Rule', () => {
       request: [
         {
           query: '',
-          httpMethod: HttpMethods.POST,
+          httpMethod: 'POST',
           operation: 'path/for/operation',
         },
       ],

--- a/test/unit/rules/armTemplate.spec.ts
+++ b/test/unit/rules/armTemplate.spec.ts
@@ -7,7 +7,7 @@ import {
   ARMTemplateRule,
   filterAsync,
   HttpMethods,
-  RequestEvaluationObject,
+  Request,
   RuleType,
 } from '../../../src/rules';
 import {ResourceManagementClient} from '@azure/arm-resources';
@@ -176,7 +176,7 @@ describe('ARM Template Rule', () => {
     const result = rule.getRequestUrl(
       testARMTarget,
       template.resources[0],
-      evaluation.request[0] as RequestEvaluationObject
+      evaluation.request[0] as Request
     );
     const expectedResult = `https://management.azure.com/subscriptions/${testARMTarget.subscriptionId}/resourceGroups/${testARMTarget.groupName}/providers/${template.resources[0].type}/${template.resources[0].name}/${evaluation.request[0].operation}?api-version=${template.resources[0].apiVersion}`;
     expect(result).to.equal(expectedResult);

--- a/test/unit/rules/azureResourceGraph.spec.ts
+++ b/test/unit/rules/azureResourceGraph.spec.ts
@@ -104,9 +104,9 @@ describe('Resource Graph Rule', () => {
   it('can get the provider, subscription id, and resource type From a resource id', () => {
     const testSubId = '0000-000-000-000';
     const resourceId = `/subscriptions/${testSubId}/resourceGroups/aza-demo/providers/Microsoft.EventHub/namespaces/misconfigRule1`;
-    const subscription = rule.getElementFromId('subscription', resourceId);
-    const provider = rule.getElementFromId('provider', resourceId);
-    const resourceType = rule.getElementFromId('resourceType', resourceId);
+    const subscription = rule.getIdElement(resourceId, 'subscriptionId');
+    const provider = rule.getIdElement(resourceId, 'provider');
+    const resourceType = rule.getIdElement(resourceId, 'resourceType');
     expect(subscription).to.equal(testSubId);
     expect(provider).to.equal('Microsoft.EventHub');
     expect(resourceType).to.equal('namespaces');

--- a/test/unit/scanner.spec.ts
+++ b/test/unit/scanner.spec.ts
@@ -1,11 +1,12 @@
 import {assert} from 'chai';
-import {getTestRules} from '..';
+import {Scanner} from '../../src/scanner';
 
 describe('Scanner', function () {
   this.slow(5000);
   this.timeout(8000);
   it('can load rules from a JSON file', async () => {
-    const rules = await getTestRules();
+    const scanner = new Scanner();
+    const rules = await scanner.getRulesFromFile('./test/rules.json');
     for (const r of rules) {
       assert.containsAllKeys(r, ['name', 'description', 'type']);
     }


### PR DESCRIPTION
closes #92 

- adds @azure/core-http for HttpMethods and removes the enum
- changes RequestEvaluationObject Name
-  changes  the send request url to get the credential token to https://management.azure.com/.default
- getIdElement method uses named groups instead of regex match 
- removes global test rules